### PR TITLE
Improve compatibility with react-widgets

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "open-sans": "git://github.com/bungeshea/open-sans.git",
     "react": "^0.12.2",
     "react-components": "git://github.com/Khan/react-components.git",
-    "react-widgets": "^2.1",
+    "react-widgets": "^2.2.1",
     "normalize.css": "~3.0.2",
     "react-data-components": "^0.1.0",
     "react-textarea-autosize": "^1.0.6",

--- a/packages/calendar-dropdown/calendar-dropdown.scss
+++ b/packages/calendar-dropdown/calendar-dropdown.scss
@@ -43,123 +43,122 @@ $state-color-hover: #333;
 $list-bg-hover: $state-bg-hover;
 $list-border-hover: $state-border-hover;
 
-.rw-widget {
-  position: relative;
-  outline: 0;
-  -moz-background-clip: border-box;
-  -webkit-background-clip: border-box;
-  background-clip: border-box;
-  background-color: $input-bg;
-  border: $input-border $input-border-width solid;
-  border-radius: $input-border-radius;
+.rw-datetimepicker {
+  padding-right: 1.9em;
 
-  .rw-input {
-    border-top-left-radius: $input-border-radius;
-    border-bottom-left-radius: $input-border-radius;
-  }
-
-  > .rw-select {
-    border-left: $input-border 1px solid;
-  }
-
-  &.rw-state-focus,
-  &.rw-state-focus:hover {
-    box-shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px opacify($input-border-focus, .6);
-    border-color: $input-border-focus;
+  &.rw-widget {
+    position: relative;
     outline: 0;
-  }
+    -moz-background-clip: border-box;
+    -webkit-background-clip: border-box;
+    background-clip: border-box;
+    background-color: $input-bg;
+    border: $input-border $input-border-width solid;
+    border-radius: $input-border-radius;
 
-  &.rw-state-readonly,
-  &.rw-state-readonly > .rw-multiselect-wrapper {
-    cursor: not-allowed;
-  }
+    .rw-input {
+      border-top-left-radius: $input-border-radius;
+      border-bottom-left-radius: $input-border-radius;
+    }
 
-  &.rw-state-disabled {
-    &,
-    &:hover,
-    &:active {
-      box-shadow: none;
-      background-color: $input-bg-disabled;
-      border-color: $input-border;
+    > .rw-select {
+      border-left: $input-border 1px solid;
+    }
+
+    &.rw-state-focus,
+    &.rw-state-focus:hover {
+      box-shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px opacify($input-border-focus, .6);
+      border-color: $input-border-focus;
+      outline: 0;
+    }
+
+    &.rw-state-readonly,
+    &.rw-state-readonly > .rw-multiselect-wrapper {
+      cursor: not-allowed;
+    }
+
+    &.rw-state-disabled {
+      &,
+      &:hover,
+      &:active {
+        box-shadow: none;
+        background-color: $input-bg-disabled;
+        border-color: $input-border;
+      }
+    }
+
+    &.rw-rtl {
+
+      .rw-input {
+        border-top-left-radius: 0;
+        border-bottom-left-radius: 0;
+        border-top-left-radius: $input-border-radius;
+        border-bottom-left-radius: $input-border-radius;
+      }
+
+      > .rw-select {
+        border-right: $input-border 1px solid;
+        border-left: none;
+      }
     }
   }
-}
 
-.rw-rtl.rw-widget {
-
-  .rw-input {
-    border-top-left-radius: 0;
+  &.rw-open.rw-widget,
+  &.rw-open > .rw-select-wrapper {
     border-bottom-left-radius: 0;
-    border-top-left-radius: $input-border-radius;
-    border-bottom-left-radius: $input-border-radius;
+    border-bottom-right-radius: 0;
   }
 
-  > .rw-select {
-    border-right: $input-border 1px solid;
-    border-left: none;
-  }
-}
-
-.rw-open.rw-widget,
-.rw-open > .rw-select-wrapper {
-  border-bottom-left-radius: 0;
-  border-bottom-right-radius: 0;
-}
-
-.rw-select {
-  position: absolute;
-  width: 1.9em;
-  height: 100%;
-  right: 0;
-
-  &.rw-btn,
-  & > .rw-btn {
+  .rw-select {
+    position: absolute;
+    width: 1.9em;
     height: 100%;
-    vertical-align: middle;
-    outline: 0;
+    right: 0;
+
+    &.rw-btn,
+    & > .rw-btn {
+      height: 100%;
+      vertical-align: middle;
+      outline: 0;
+    }
+
+    .rw-rtl & {
+      left: 0;
+      right: auto;
+    }
   }
 
-  .rw-rtl & {
-    left: 0;
-    right: auto;
+  .rw-state-focus {
+    background-color: $state-bg-focus;
+    border: $state-border-focus 1px solid;
+    color: $state-color-focus;
   }
-}
 
-.rw-state-focus {
-  background-color: $state-bg-focus;
-  border: $state-border-focus 1px solid;
-  color: $state-color-focus;
-}
+  .rw-i {
+    display: inline-block;
+    font-family: RwWidgets;
+    font-style: normal;
+    font-weight: normal;
+    line-height: 1em;
+    font-variant: normal;
+    text-transform: none;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+  }
 
+  .rw-i-clock-o:after { content:'\e80c'; }
+  .rw-i-calendar:after { content: '\e808'; }
 
-.rw-i {
-  display: inline-block;
-  font-family: RwWidgets;
-  font-style: normal;
-  font-weight: normal;
-  line-height: 1em;
-  font-variant: normal;
-  text-transform: none;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-}
-
-.rw-i-clock-o:after { content:'\e80c'; }
-.rw-i-calendar:after { content: '\e808'; }
-
-.rw-sr {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  margin: -1px;
-  padding: 0;
-  overflow: hidden;
-  clip: rect(0,0,0,0);
-  border: 0;
-}
-
-.rw-datepicker {
-  padding-right: 1.9em;
+  .rw-sr {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    margin: -1px;
+    padding: 0;
+    overflow: hidden;
+    clip: rect(0,0,0,0);
+    border: 0;
+  }
 
   > .rw-select > .rw-btn {
     color: $btn-color;
@@ -222,87 +221,87 @@ $list-border-hover: $state-border-hover;
     width: 3.8em;
     height: 100%;
   }
-}
 
-.rw-popup {
-  -webkit-box-shadow: 0 5px 6px rgba(0,0,0,0.2);
-  box-shadow: 0 5px 6px rgba(0,0,0,0.2);
-  border-top-left-radius: 0;
-  border-top-right-radius: 0;
-  border-bottom-left-radius: $border-radius-sm;
-  border-bottom-right-radius: $border-radius-sm;
-  border: $popup-border 1px solid;
-  background: $popup-bg;
-  padding: 2px;
-  width: 100%;
-  overflow: auto;
-}
-
-.rw-popup-container {
-  position: absolute;
-  top: 100%;
-  margin-top: 1px;
-  left: -$input-border-width;
-  right: -$input-border-width;
-  z-index: $popup-zindex;
-
-  &.rw-calendar-popup {
-    right: auto;
-    width: 200px; //15em; ?
-  }
-}
-
-ul.rw-list {
-  margin: 0;
-  padding-left: 0;
-  list-style: none;
-  padding: 5px 0;
-  overflow: auto;
-  outline: 0;
-  height: 100%;
-
-  > li {
-    cursor: pointer;
-    border: 1px solid transparent;
-    padding-left: 10px;
-    padding-right: 10px;
-    border-radius: $border-radius-sm;
+  .rw-popup {
+    -webkit-box-shadow: 0 5px 6px rgba(0,0,0,0.2);
+    box-shadow: 0 5px 6px rgba(0,0,0,0.2);
+    border-top-left-radius: 0;
+    border-top-right-radius: 0;
+    border-bottom-left-radius: $border-radius-sm;
+    border-bottom-right-radius: $border-radius-sm;
+    border: $popup-border 1px solid;
+    background: $popup-bg;
+    padding: 2px;
+    width: 100%;
+    overflow: auto;
   }
 
-  > li:hover {
-    background-color: $list-bg-hover;
-    border-color: $list-border-hover;
+  .rw-popup-container {
+    position: absolute;
+    top: 100%;
+    margin-top: 1px;
+    left: -$input-border-width;
+    right: -$input-border-width;
+    z-index: $popup-zindex;
+
+    &.rw-calendar-popup {
+      right: auto;
+      width: 200px; //15em; ?
+    }
   }
 
-  > li.rw-state-focus {
-    background-color: $state-bg-focus;
-    border: $state-border-focus 1px solid;
-    color: $state-color-focus;
+  ul.rw-list {
+    margin: 0;
+    padding-left: 0;
+    list-style: none;
+    padding: 5px 0;
+    overflow: auto;
+    outline: 0;
+    height: 100%;
+
+    > li {
+      cursor: pointer;
+      border: 1px solid transparent;
+      padding-left: 10px;
+      padding-right: 10px;
+      border-radius: $border-radius-sm;
+    }
+
+    > li:hover {
+      background-color: $list-bg-hover;
+      border-color: $list-border-hover;
+    }
+
+    > li.rw-state-focus {
+      background-color: $state-bg-focus;
+      border: $state-border-focus 1px solid;
+      color: $state-color-focus;
+    }
+
+    > li.rw-state-selected {
+      background-color: $state-bg-focus;
+      border: $state-border-focus 1px solid;
+      color: $state-color-focus;
+    }
   }
 
-  > li.rw-state-selected {
-    background-color: $state-bg-focus;
-    border: $state-border-focus 1px solid;
-    color: $state-color-focus;
-  }
-}
+  .rw-input {
+    color: $input-color;
+    height: $input-height;
+    line-height: $input-height;
+    padding: 0.177em 0;
+    text-indent: 0.64em;
 
-.rw-input {
-  color: $input-color;
-  height: $input-height;
-  line-height: $input-height;
-  padding: 0.177em 0;
-  text-indent: 0.64em;
+    &[disabled] {
+      -webkit-box-shadow: none; // iOS <4.3 & Android <4.1
+      box-shadow: none;
+      opacity: 1;
+      background-color: $input-bg-disabled;
+      border-color: $input-border;
+    }
 
-  &[disabled] {
-    -webkit-box-shadow: none; // iOS <4.3 & Android <4.1
-    box-shadow: none;
-    opacity: 1;
-    background-color: $input-bg-disabled;
-    border-color: $input-border;
-  }
-
-  &[readonly] {
-    cursor: not-allowed;
+    &[readonly] {
+      cursor: not-allowed;
+    }
   }
 }

--- a/packages/calendar/calendar.scss
+++ b/packages/calendar/calendar.scss
@@ -31,6 +31,18 @@ $color-calendar-hover-date: $color-gallery;
     padding-right: 10px;
   }
 
+  .rw-i {
+    display: inline-block;
+    font-family: RwWidgets;
+    font-style: normal;
+    font-weight: normal;
+    line-height: 1em;
+    font-variant: normal;
+    text-transform: none;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+  }
+
   .rw-i-caret-down:after { content: '\e801'; }
   .rw-i-caret-up:after { content: '\e800'; }
   .rw-i-caret-left:after { content: '\e807';  }

--- a/packages/tag-input/tag-input.scss
+++ b/packages/tag-input/tag-input.scss
@@ -6,8 +6,79 @@ $color-option-hover: $color-gallery;
 $color-option-text: $color-scorpion;
 $color-glow: $color-border;
 
+$line-height: 1.94em;
+
+$border-radius: 4px;
+$border-radius-sm: 3px;
+
+$input-color: #555;
+$input-height: $line-height;
+$input-bg: $color-white;
+$input-bg-disabled: #eee;
+$input-border: #ccc;
+$input-border-focus: #66afe9;
+$input-border-width: 1px;
+$input-border-radius: $border-radius;
+
 .rw-multiselect {
   position: relative;
+
+  &.rw-widget {
+    position: relative;
+    outline: 0;
+    -moz-background-clip: border-box;
+    -webkit-background-clip: border-box;
+    background-clip: border-box;
+    background-color: $input-bg;
+    border: $input-border $input-border-width solid;
+    border-radius: $input-border-radius;
+
+    .rw-input {
+      border-top-left-radius: $input-border-radius;
+      border-bottom-left-radius: $input-border-radius;
+    }
+
+    > .rw-select {
+      border-left: $input-border 1px solid;
+    }
+
+    &.rw-state-focus,
+    &.rw-state-focus:hover {
+      box-shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px opacify($input-border-focus, .6);
+      border-color: $input-border-focus;
+      outline: 0;
+    }
+
+    &.rw-state-readonly,
+    &.rw-state-readonly > .rw-multiselect-wrapper {
+      cursor: not-allowed;
+    }
+
+    &.rw-state-disabled {
+      &,
+      &:hover,
+      &:active {
+        box-shadow: none;
+        background-color: $input-bg-disabled;
+        border-color: $input-border;
+      }
+    }
+
+    &.rw-rtl {
+
+      .rw-input {
+        border-top-left-radius: 0;
+        border-bottom-left-radius: 0;
+        border-top-left-radius: $input-border-radius;
+        border-bottom-left-radius: $input-border-radius;
+      }
+
+      > .rw-select {
+        border-right: $input-border 1px solid;
+        border-left: none;
+      }
+    }
+  }
 
   &:focus, *:focus {
     outline: none;


### PR DESCRIPTION
Fixes a number of style issues introduced after we upgraded to React 0.12, and bumps react-widgets to 2.2.1.
Also improves isolation of component styles; previously the calendar dropdown's styles affected the tag-input.
Fixes #152.