### PR TITLE
extend button api and type attribute deprecation

### DIFF
--- a/packages/button/button.scss
+++ b/packages/button/button.scss
@@ -1,6 +1,19 @@
+@import "colors";
+
 $button-font-family: 'Open Sans', 'Helvetica Neue', 'Arial', 'Helvetica', 'sans-serif' !default;
 $button-font-weight: 400 !default;
 $button-font-size: .8em !default;
+
+$color-button-default: $color-white !default;
+$color-button-default-background: $color-fountain-blue !default;
+
+$color-button-success: $color-white !default;
+$color-button-success-background: $color-sushi !default;
+
+$color-button-cancel: $color-white !default;
+$color-button-cancel-background: $color-alizarin-crimson !default;
+
+$color-button-skeleton: $color-scorpion !default;
 
 .Button {
   display: inline-block;
@@ -15,8 +28,8 @@ $button-font-size: .8em !default;
   font-weight: $button-font-weight;
   text-align: center;
   text-shadow: 0 1px 0 rgba(#000, .15);
-  color: white;
-  background-color: grey;
+  color: $color-button-default;
+  background-color: $color-button-default-background;
   background-image: linear-gradient(to bottom, rgba(#000, 0) 50%, rgba(#000, .1) 100%);
   white-space: nowrap;
   user-select: none;
@@ -34,4 +47,25 @@ $button-font-size: .8em !default;
   &:hover {
     opacity: .9;
   }
+}
+
+.Button--success {
+  color: $color-button-success;
+  background-color: $color-button-success-background;
+}
+
+.Button--cancel {
+  color: $color-button-cancel;
+  background-color: $color-button-cancel-background;
+}
+
+.Button--skeleton {
+  color: $color-button-skeleton;
+  background-color: transparent;
+}
+
+.Button--small {
+  padding: 0 1em;
+  height: 2em;
+  line-height: 2em;
 }

--- a/packages/button/example.jsx
+++ b/packages/button/example.jsx
@@ -25,9 +25,15 @@ module.exports = React.createClass({
         <br/>
         Clicked {this.state.count} time{this.state.count === 1 ? '' : 's'}
         <br/><br/>
-        <Button type="huedemo">Has background-color support</Button>
+        <Button className="Button--huedemo">Has the ability to hack in variants</Button>
         <br/>
-        <Button type="huedemo" disabled>Can be disabled!</Button>
+        <Button disabled>Can be disabled!</Button>
+        <br/>
+        <Button small>Can be small!</Button>
+        <br/>
+        <Button success>Can be success!</Button>
+        <br/>
+        <Button cancel>Can be cancel!</Button>
       </div>
     );
   }

--- a/packages/button/index.jsx
+++ b/packages/button/index.jsx
@@ -2,19 +2,57 @@
 
 require('./button.scss');
 
-var React = require('react');
+var React = require('react/addons');
+var classSet = React.addons.classSet;
+var _ = require('lodash-node');
+
+var validTypes = [
+  'submit',
+  'reset',
+  'button',
+];
 
 module.exports = React.createClass({
   displayName: 'Button',
 
+  propTypes: {
+    small: React.PropTypes.bool,
+    skeleton: React.PropTypes.bool,
+    success: React.PropTypes.bool,
+    cancel: React.PropTypes.bool,
+    type: function(props, propName) {
+      if (
+        propName in props &&
+        !_.contains(validTypes, props[propName])
+      ) {
+        // type is deprecated because it overlaps with the built in html attribute
+        return new Error('Button\'s type[' + props[propName] +'] property is deprecated outside of [' + validTypes.join(', ') + ']. Please extend the component instead.');
+      }
+    },
+  },
+
   getDefaultProps: function() {
     return {
-      type: 'default'
+      small: false,
+      skeleton: false,
+      success: false,
+      cancel: false,
     };
   },
 
   render: function() {
-    var buttonClass = 'Button Button--' + this.props.type;
+    var classes = {
+      'Button': true,
+      'Button--small': this.props.small,
+      'Button--skeleton': this.props.skeleton,
+      'Button--success': this.props.success,
+      'Button--cancel': this.props.cancel,
+    };
+
+    classes['Button--' + this.props.type] = true;
+    classes[this.props.className] = true;
+
+    var buttonClass = classSet(classes);
 
     return (
       <button {...this.props} className={buttonClass}>{this.props.children}</button>


### PR DESCRIPTION
![screen shot 2015-02-03 at 11 52 27 am](https://cloud.githubusercontent.com/assets/33324/6012390/b4fac9fe-ab9b-11e4-9855-789134dfedbb.png)

Basic api for the main types of buttons I saw in stack client, willing to take this further.
I don't like the way the colours work because the only overridable colours are listed by name, but thats an existing issue. I'm open for suggestions on a naming scheme that is easier to override for colours.