### PR TITLE
Cancelable edit

### DIFF
--- a/packages/cancelable-edit/example.jsx
+++ b/packages/cancelable-edit/example.jsx
@@ -23,10 +23,10 @@ module.exports = React.createClass({
       <div>
         <pre> {/*lol es6 literals are too literal */}
 {`<CancelableEdit
-   value={this.state.name}
-   onSave={this.handleNameSave}
-   placeholder="Name"
-   allowEmpty={false}
+    value={this.state.name}
+    onSave={this.handleNameSave}
+    placeholder="Name"
+    displayName="Name"
   />`}
         </pre>
         <CancelableEdit
@@ -34,7 +34,6 @@ module.exports = React.createClass({
           onSave={this.handleNameSave}
           displayName="Name"
           placeholder="Name"
-          allowEmpty
         />
       </div>
     );

--- a/packages/cancelable-edit/example.jsx
+++ b/packages/cancelable-edit/example.jsx
@@ -1,0 +1,42 @@
+var React = require('react');
+
+var CancelableEdit = require('./');
+
+
+module.exports = React.createClass({
+  displayName: 'EditiableFieldExample',
+
+  getInitialState() {
+    return {
+      name: 'John smith',
+    };
+  },
+
+  handleNameSave(name) {
+    this.setState({
+      name: name,
+    });
+  },
+
+  render() {
+    return (
+      <div>
+        <pre> {/*lol es6 literals are too literal */}
+{`<CancelableEdit
+   value={this.state.name}
+   onSave={this.handleNameSave}
+   placeholder="Name"
+   allowEmpty={false}
+  />`}
+        </pre>
+        <CancelableEdit
+          value={this.state.name}
+          onSave={this.handleNameSave}
+          displayName="Name"
+          placeholder="Name"
+          allowEmpty
+        />
+      </div>
+    );
+  }
+});

--- a/packages/cancelable-edit/example.jsx
+++ b/packages/cancelable-edit/example.jsx
@@ -25,6 +25,7 @@ module.exports = React.createClass({
 {`<CancelableEdit
     value={this.state.name}
     onSave={this.handleNameSave}
+    autoSize
     placeholder="Name"
     displayName="Name"
   />`}
@@ -32,6 +33,7 @@ module.exports = React.createClass({
         <CancelableEdit
           value={this.state.name}
           onSave={this.handleNameSave}
+          autoSize
           displayName="Name"
           placeholder="Name"
         />

--- a/packages/cancelable-edit/index.jsx
+++ b/packages/cancelable-edit/index.jsx
@@ -4,10 +4,25 @@ var React = require('react/addons');
 var AutoSizeTextArea = require('react-textarea-autosize');
 
 var Button = require('../button');
+var KeyMixin = require('../key-mixin');
 
 require('./style');
 
+var hotKeys = [
+  {
+    mask: {key: 'Enter', metaKey: true, altKey: false}, //osx
+    cb: 'handleSave',
+  },{
+    mask: {key: 'Enter', ctrlKey: true, altKey: false}, //windows
+    cb: 'handleSave',
+  },{
+    mask: {key: 'Escape', ctrlKey: false, altKey: false},
+    cb: 'handleCancel',
+  },
+];
+
 var CancelableEdit = React.createClass({
+  mixins: [KeyMixin],
   propTypes: {
     warnMessage: React.PropTypes.string,
     displayName: React.PropTypes.string,
@@ -78,6 +93,7 @@ var CancelableEdit = React.createClass({
       <div>
         <label style={{'display': 'none'}}>{this.props.name}</label>
         <Textarea
+          onKeyDown={this.keyHandler(hotKeys)}
           className="CancelableEdit"
           value={value}
           onClick={this.handleClick}

--- a/packages/cancelable-edit/index.jsx
+++ b/packages/cancelable-edit/index.jsx
@@ -28,6 +28,7 @@ var CancelableEdit = React.createClass({
     displayName: React.PropTypes.string,
     small: React.PropTypes.bool,
     allowEmpty: React.PropTypes.bool,
+    autoSize: React.PropTypes.bool,
     onSave: React.PropTypes.func.isRequired,
   },
 
@@ -44,6 +45,7 @@ var CancelableEdit = React.createClass({
       displayName: '',
       small: false,
       allowEmpty: false,
+      autoSize: false,
       onSave: () => {},
     };
   },
@@ -88,7 +90,7 @@ var CancelableEdit = React.createClass({
   render() {
     var value = this.state.editing ? this.state.pendingValue : this.props.value;
 
-    var Textarea = this.props.autosize ? AutoSizeTextArea : 'textarea';
+    var Textarea = this.props.autoSize ? AutoSizeTextArea : 'textarea';
     return (
       <div>
         <label style={{'display': 'none'}}>{this.props.name}</label>

--- a/packages/cancelable-edit/index.jsx
+++ b/packages/cancelable-edit/index.jsx
@@ -1,0 +1,94 @@
+// Pending a decent name!
+
+var React = require('react/addons');
+var AutoSizeTextArea = require('react-textarea-autosize');
+
+var Button = require('../button');
+
+require('./style');
+
+var CancelableEdit = React.createClass({
+  getInitialState() {
+    return {
+      editing: false,
+      pendingValue: '',
+    };
+  },
+
+  getDefaultProps() {
+    return {
+      small: false,
+      allowEmpty: false,
+      onSave: () => {},
+    };
+  },
+
+  handleChange(e) {
+    this.setState({
+      pendingValue: e.target.value,
+    });
+  },
+
+  handleCancel(e) {
+    if (this.props.value === this.state.pendingValue ||
+      confirm('Are you sure you want to discard your changes?')
+    ) {
+      this.setState({editing: false});
+    }
+  },
+
+  handleSave() {
+    if (this.props.allowEmpty || (this.state.pendingValue !== '')) {
+      this.setState({
+        editing: false
+      },
+        () => this.props.onSave(this.state.pendingValue)
+      );
+    }
+  },
+
+  unsaved() {
+    return this.state.editing && (this.props.value !== this.state.pendingValue);
+  },
+
+  handleClick(e) {
+    if (!this.state.editing) {
+      this.setState({
+        editing: true,
+        pendingValue: this.props.value,
+      });
+    }
+  },
+
+  render() {
+    var value = this.state.editing ? this.state.pendingValue : this.props.value;
+
+    var Textarea = this.props.autosize ? AutoSizeTextArea : 'textarea';
+    return (
+      <div>
+        <label style={{'display': 'none'}}>{this.props.name}</label>
+        <Textarea
+          className={'CancelableEdit'}
+          value={value}
+          onClick={this.handleClick}
+          onChange={this.handleChange}
+          name={this.props.name}
+          readOnly={!this.state.editing}
+          placeholder={this.props.placeholder}
+        />
+        { this.state.editing &&
+          <div className="CancelableEdit-control">
+            <Button small={this.props.small} skeleton onClick={this.handleCancel}>
+              Cancel
+            </Button>
+            <Button small={this.props.small} success onClick={this.handleSave}>
+              Save {this.props.displayName}
+            </Button>
+          </div>
+        }
+      </div>
+    );
+  }
+});
+
+module.exports = CancelableEdit;

--- a/packages/cancelable-edit/index.jsx
+++ b/packages/cancelable-edit/index.jsx
@@ -9,11 +9,13 @@ require('./style');
 
 var CancelableEdit = React.createClass({
   propTypes: {
+    warnMessage: React.PropTypes.string,
     displayName: React.PropTypes.string,
     small: React.PropTypes.bool,
     allowEmpty: React.PropTypes.bool,
     onSave: React.PropTypes.func.isRequired,
   },
+
   getInitialState() {
     return {
       editing: false,
@@ -23,6 +25,8 @@ var CancelableEdit = React.createClass({
 
   getDefaultProps() {
     return {
+      warnMessage: 'Are you sure you want to discard your changes?',
+      displayName: '',
       small: false,
       allowEmpty: false,
       onSave: () => {},
@@ -37,7 +41,7 @@ var CancelableEdit = React.createClass({
 
   handleCancel(e) {
     if (this.props.value === this.state.pendingValue ||
-      confirm('Are you sure you want to discard your changes?')
+      confirm(this.props.warnMessage)
     ) {
       this.setState({editing: false});
     }

--- a/packages/cancelable-edit/index.jsx
+++ b/packages/cancelable-edit/index.jsx
@@ -1,5 +1,3 @@
-// Pending a decent name!
-
 var React = require('react/addons');
 var AutoSizeTextArea = require('react-textarea-autosize');
 
@@ -65,6 +63,8 @@ var CancelableEdit = React.createClass({
   handleCancel(e) {
     if (this.unsaved()) {
       this.setState({showAlert: true});
+    } else {
+      this.setState({editing: false});
     }
   },
 

--- a/packages/cancelable-edit/index.jsx
+++ b/packages/cancelable-edit/index.jsx
@@ -3,6 +3,7 @@
 var React = require('react/addons');
 var AutoSizeTextArea = require('react-textarea-autosize');
 
+var Alert = require('../alert');
 var Button = require('../button');
 var KeyMixin = require('../key-mixin');
 
@@ -36,6 +37,7 @@ var CancelableEdit = React.createClass({
     return {
       editing: false,
       pendingValue: '',
+      showAlert: false,
     };
   },
 
@@ -56,18 +58,20 @@ var CancelableEdit = React.createClass({
     });
   },
 
+  handleConfirmCancel() {
+    this.setState({editing: false, showAlert: false});
+  },
+
   handleCancel(e) {
-    if (this.props.value === this.state.pendingValue ||
-      confirm(this.props.warnMessage)
-    ) {
-      this.setState({editing: false});
+    if (this.unsaved()) {
+      this.setState({showAlert: true});
     }
   },
 
   handleSave() {
     if (this.props.allowEmpty || (this.state.pendingValue !== '')) {
       this.setState({
-        editing: false
+        editing: false,
       },
         () => this.props.onSave(this.state.pendingValue)
       );
@@ -112,6 +116,15 @@ var CancelableEdit = React.createClass({
             <Button small={this.props.small} success onClick={this.handleSave}>
               Save {this.props.displayName}
             </Button>
+            {this.state.showAlert &&
+              <Alert
+                  cancelable
+                  onOk={this.handleConfirmCancel}
+                  onCancel={this.setState.bind(this, {showAlert: false})}
+                >
+                {this.props.warnMessage}
+              </Alert>
+            }
           </div>
         }
       </div>

--- a/packages/cancelable-edit/index.jsx
+++ b/packages/cancelable-edit/index.jsx
@@ -8,6 +8,12 @@ var Button = require('../button');
 require('./style');
 
 var CancelableEdit = React.createClass({
+  propTypes: {
+    displayName: React.PropTypes.string,
+    small: React.PropTypes.bool,
+    allowEmpty: React.PropTypes.bool,
+    onSave: React.PropTypes.func.isRequired,
+  },
   getInitialState() {
     return {
       editing: false,

--- a/packages/cancelable-edit/index.jsx
+++ b/packages/cancelable-edit/index.jsx
@@ -78,7 +78,7 @@ var CancelableEdit = React.createClass({
       <div>
         <label style={{'display': 'none'}}>{this.props.name}</label>
         <Textarea
-          className={'CancelableEdit'}
+          className="CancelableEdit"
           value={value}
           onClick={this.handleClick}
           onChange={this.handleChange}

--- a/packages/cancelable-edit/style.scss
+++ b/packages/cancelable-edit/style.scss
@@ -21,7 +21,7 @@ $color-cancelable-edit-hover-background: darken($color-white, 1) !default;
   padding: 10px;
   cursor: text;
 
-  &[readonly="readonly"], &[readonly] {
+  &[readonly] {
     background: transparent;
 
     &:hover {

--- a/packages/cancelable-edit/style.scss
+++ b/packages/cancelable-edit/style.scss
@@ -1,0 +1,50 @@
+@import "colors";
+
+$cancelable-edit-font-weight: 400 !default;
+
+$color-cancelable-edit: $color-scorpion !default;
+$color-cancelable-edit-border: $color-catskill-white !default;
+$color-cancelable-edit-background: darken($color-white, 1) !default;
+$color-cancelable-edit-hover-background: darken($color-white, 1) !default;
+
+.CancelableEdit {
+  line-height: 1.3em;
+  color: $color-cancelable-edit;
+  font-weight: $cancelable-edit-font-weight;
+  border: 1px solid $color-cancelable-edit-border;
+  background-color: $color-cancelable-edit-background;
+  outline: 0;
+  resize: none;
+  width: 100%;
+  margin-top: 10px;
+  border-radius: 3px;
+  padding: 10px;
+  cursor: text;
+
+  &[readonly="readonly"], &[readonly] {
+    //border: 1px solid transparent;
+    background: transparent;
+
+    &:hover {
+      background: $color-cancelable-edit-hover-background;
+      cursor: pointer;
+    }
+  }
+}
+
+.CancelableEdit--em{
+  font-size: 28px;
+  font-weight: $cancelable-edit-font-weight;
+  line-height: 1.5em;
+  letter-spacing: -0.05em;
+}
+
+.CancelableEdit-controls {
+  overflow: hidden;
+  padding: 0 0 10px;
+  border-bottom: 1px solid $color-cancelable-edit-border;
+  margin: 2px 0 0 0;
+  bottom: 0;
+  width: 100%;
+  text-align: right;
+}

--- a/packages/cancelable-edit/style.scss
+++ b/packages/cancelable-edit/style.scss
@@ -22,7 +22,6 @@ $color-cancelable-edit-hover-background: darken($color-white, 1) !default;
   cursor: text;
 
   &[readonly="readonly"], &[readonly] {
-    //border: 1px solid transparent;
     background: transparent;
 
     &:hover {


### PR DESCRIPTION
![screen shot 2015-02-05 at 3 37 46 pm](https://cloud.githubusercontent.com/assets/33324/6055115/f8debb6e-ad4c-11e4-8eb3-9f9ab0777ac4.png)
It restores the original value on pressing escape or clicking cancel.
It raises an event (onSave) when pressing meta+enter or clicking Save {this.props.displayName}
It warns you when cancelling
It optionally allows blank input
Edit mode is triggered on click
It optionally grows with input
