### PR TITLE
Deprecate isDiscussion property

### DIFF
--- a/packages/comments/comment.jsx
+++ b/packages/comments/comment.jsx
@@ -20,9 +20,6 @@ function dateValidator(props, propName, componentName) {
   if (propName in props && isNaN(new Date(props[propName]).getUTCMilliseconds())) {
     return new Error('Invalid value for prop `' + propName + '` in `' + componentName + '`.');
   }
-  if (!(propName in props) && propName === 'createdAt') {
-    return new Error('Required prop `' + propName + '` was not specified in `' + componentName + '`.')
-  }
 }
 
 module.exports = React.createClass({
@@ -45,7 +42,12 @@ module.exports = React.createClass({
         }
       },
       createdAt: dateValidator,
-      updatedAt: dateValidator,
+      updatedAt(props, propName, componentName) {
+        if (!(propName in props)) {
+          return new Error('Required prop `' + propName + '` was not specified in `' + componentName + '`.')
+        }
+        return dateValidator(props, propName, componentName);
+      },
     }).isRequired,
     onReply: React.PropTypes.func,
     onEdit: React.PropTypes.func,

--- a/packages/comments/comment.scss
+++ b/packages/comments/comment.scss
@@ -82,7 +82,6 @@
   }
 
   .Comment-replies {
-    padding: 10px;
     margin: 5px -10px -10px;
     background: #eee;
     box-shadow: 1px 0 0 rgba(0,0,0,.05), -1px 0 0 rgba(0,0,0,.05), 0 1px 0 rgba(0,0,0,.05);
@@ -90,6 +89,7 @@
 
   .Comment-replies-new {
     @extend %clearfix;
+    padding: 10px;
   }
 
   .Comment-replies-new-input {
@@ -101,10 +101,15 @@
     height: 30px;
     resize: none;
   }
+
   .Comment-reply {
     border-bottom: 1px solid #ddd;
-    margin: 0 -10px 10px;
-    padding: 0 10px 5px;
+    padding: 10px 10px 5px 10px;
+
+    &:last-child {
+      border-bottom: 0;
+    }
+
     .Comment-text {
       padding-top: 5px;
       margin-left: 45px;

--- a/packages/comments/example.jsx
+++ b/packages/comments/example.jsx
@@ -69,7 +69,7 @@ module.exports = React.createClass({
           id: 6,
           author: authors[0],
           entry: 'This is some event',
-          isDiscussion: false,
+          repliable: false,
           editable: false,
           deletable: false,
           createdAt: '2015-01-07T11:04:01.453783131+11:00'


### PR DESCRIPTION
Replaced with `repliable`, which makes a lot more sense and makes it a lot more generic.
Warnings have been added for when `isDiscussion` is supplied, and comment's format has been defined.
Also allows displaying responses to a non-repliable comment.