### PR TITLE
Routes for examples

### DIFF
--- a/app/index.jsx
+++ b/app/index.jsx
@@ -72,7 +72,7 @@ Router.run(
     <Route name="all" path="/" handler={AllComponentsHandler}/>
     {packages.map(component =>
       <Route name={component.name} path={'/' + component.name} handler={React.createClass({
-        displayName: component.friendlyName.split(' ').join('')+'ExampleRouteHandler',
+        displayName: component.friendlyName.split(' ').join('') + 'ExampleRouteHandler',
         render() {return wrapPackage(component);}
       })}/>
     )}

--- a/app/index.jsx
+++ b/app/index.jsx
@@ -8,7 +8,7 @@ var Link = Router.Link;
 var RouteHandler = Router.RouteHandler;
 
 require('open-sans/scss/open-sans.scss');
-require('normalize.css/normalize.css')
+require('normalize.css/normalize.css');
 require('./index.scss');
 
 var packageRequire = require.context('../packages', true, /example\.jsx/);
@@ -71,15 +71,14 @@ var AllComponentsHandler = React.createClass({
 Router.run(
   <Route name="app" path="/" handler={App}>
     <Route name="all" path="/" handler={AllComponentsHandler}/>
-    {packages.map(component => 
+    {packages.map(component =>
       <Route name={component.name} path={'/' + component.name} handler={React.createClass({
-        displayName: component.name,
+        displayName: component.friendlyName.split(' ').join('')+'ExampleRouteHandler',
         render() {return wrapPackage(component);}
       })}/>
     )}
   </Route>,
-  Router.HistoryLocation,
-  (Handler, state) => {
+  Handler => {
     React.render(
       <Handler />,
       document.body

--- a/app/index.jsx
+++ b/app/index.jsx
@@ -2,21 +2,14 @@
 
 var _ = require('lodash-node');
 var React = require('react');
+var Router = require('react-router');
+var Route = Router.Route;
+var Link = Router.Link;
+var RouteHandler = Router.RouteHandler;
 
 require('open-sans/scss/open-sans.scss');
 require('normalize.css/normalize.css')
 require('./index.scss');
-
-var Component = React.createClass({
-  render() {
-    return (
-      <div className="Playground-Example">
-        <h2 id={this.props.package.name}>{this.props.package.friendlyName} ({this.props.package.name})</h2>
-        <div>{this.props.children}</div>
-      </div>
-    );
-  },
-});
 
 var packageRequire = require.context('../packages', true, /example\.jsx/);
 
@@ -34,20 +27,62 @@ var packages = _.map(packageRequire.keys(), packagePath => {
 
 });
 
-var packageContents = _.map(packages, component => <li key={component.path}><a href={'#' + component.name}>{component.friendlyName}</a></li>);
-var packages = _.map(packages, (component) => {
+function wrapPackage(component) {
   var Example = packageRequire(component.path);
 
-  return <Component key={component.path} package={component} ><Example /></Component>;
+  return (
+    <div className="Playground-Example" key={component.name}>
+      <h2 id={component.name}>{component.friendlyName} ({component.name})</h2>
+      <div><Example /></div>
+    </div>
+  );
+}
+
+var App = React.createClass({
+  displayName: 'App',
+
+  render() {
+    return (
+      <div>
+        <h1>Macropod Components</h1>
+        <h2>Table of Contents</h2>
+        <ul className="Playground-TOC">
+          <li><Link to="/">All</Link></li>
+          {packages.map(component => <li key={component.path}><Link to={'/' + component.name}>{component.friendlyName}</Link></li>)}
+        </ul>
+        <RouteHandler />
+      </div>
+    );
+  }
 });
 
-React.render(
-  <div>
-    <h1>React Playground</h1>
-    <h2>Table of Contents</h2>
-    <ul className="Playground-TOC">
-      {packageContents}
-    </ul>
-      {packages}
-  </div>,
- document.body);
+var AllComponentsHandler = React.createClass({
+  displayName: 'AllComponentsHandler',
+
+  render() {
+    return (
+      <div>
+        {packages.map(wrapPackage)}
+      </div>
+    );
+  }
+});
+
+Router.run(
+  <Route name="app" path="/" handler={App}>
+    <Route name="all" path="/" handler={AllComponentsHandler}/>
+    {packages.map(component => 
+      <Route name={component.name} path={'/' + component.name} handler={React.createClass({
+        displayName: component.name,
+        render() {return wrapPackage(component);}
+      })}/>
+    )}
+  </Route>,
+  Router.HistoryLocation,
+  (Handler, state) => {
+    React.render(
+      <Handler />,
+      document.body
+   );
+  }
+);

--- a/app/index.jsx
+++ b/app/index.jsx
@@ -45,7 +45,6 @@ var App = React.createClass({
     return (
       <div>
         <h1>Macropod Components</h1>
-        <h2>Table of Contents</h2>
         <ul className="Playground-TOC">
           <li><Link to="/">All</Link></li>
           {packages.map(component => <li key={component.path}><Link to={'/' + component.name}>{component.friendlyName}</Link></li>)}

--- a/app/index.scss
+++ b/app/index.scss
@@ -2,14 +2,18 @@
   box-sizing: border-box;
 }
 
+html {
+  min-height: 200%;
+}
+
 body {
   font-family: 'Open Sans', 'Helvetica Neue', 'Arial', 'Helvetica', 'sans-serif';
   font-size: 15px;
-  padding: 0px;
+  padding: 0;
   width: 1200px;
   max-width: 100%;
   padding: 0 1em;
-  margin: 5em auto;
+  margin: 1em auto;
 }
 
 code {
@@ -17,17 +21,35 @@ code {
 }
 
 .Playground-TOC {
-  column-width: 10em;
+  column-width: 12em;
   padding: 0;
+  list-style: none;
 
   > li {
     column-break-inside: avoid;
+    margin-bottom: .2em;
+
+    a {
+      color: black;
+      text-decoration: none;
+      padding: .1em .3em;
+      border-radius: .2em;
+
+      &:hover {
+        opacity: .4;
+      }
+
+      &.active {
+        color: white;
+        background-color: black;
+      }
+    }
   }
 }
 
 .Playground-Example {
   box-sizing: border-box;
-  margin: 0px;
+  margin: 0;
   padding-bottom: 1.5em;
   border-bottom: 1px solid #ccc;
 

--- a/app/index.scss
+++ b/app/index.scss
@@ -19,6 +19,10 @@ code {
 .Playground-TOC {
   column-width: 10em;
   padding: 0;
+
+  > li {
+    column-break-inside: avoid;
+  }
 }
 
 .Playground-Example {

--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>Macropod Playground</title>
+    <title>Macropod Components</title>
   </head>
   <body>
     <div id="content"></div>

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "open-sans": "git://github.com/bungeshea/open-sans.git",
     "react": "^0.12.2",
     "react-components": "git://github.com/Khan/react-components.git",
+    "react-router": "^0.11.6",
     "react-widgets": "^2.2.1",
     "normalize.css": "~3.0.2",
     "react-data-components": "^0.1.0",


### PR DESCRIPTION
![screen shot 2015-02-10 at 4 43 05 pm](https://cloud.githubusercontent.com/assets/282113/6122210/0f1cbb56-b144-11e4-85ec-c81e6f36e028.png)

Gives each example its own route (using `react-router`).

This is another step on the path to making this ready for human consumption. My thought is that in the future, the examples will include documentation alongside.