### PR TITLE
Fix hotkey interactions

### DIFF
--- a/packages/alert/index.jsx
+++ b/packages/alert/index.jsx
@@ -42,12 +42,6 @@ module.exports = React.createClass({
     };
   },
 
-  handleKeyUp(event) {
-    if (event.keyCode === 13) {
-      this.props.onOk();
-    }
-  },
-
   handleCancel() {
     this.props.onCancel();
     return false;
@@ -58,6 +52,10 @@ module.exports = React.createClass({
     return false;
   },
 
+  componentDidMount() {
+    this.refs.ok.getDOMNode().focus();
+  },
+
   render() {
     return (
       <Modal dialogClassName="Alert" onClose={this.handleCancel} title={this.props.title} closeButton={true}>
@@ -65,7 +63,7 @@ module.exports = React.createClass({
           {this.props.children}
           <div className="Alert-actions">
             {this.props.cancelable && <Button cancel onClick={this.handleCancel}>{this.props.cancelText}</Button>}
-            <Button onClick={this.handleOk} danger={this.props.danger} disabled={this.props.okDisabled}>{this.props.okText}</Button>
+            <Button ref="ok" onClick={this.handleOk} danger={this.props.danger} disabled={this.props.okDisabled}>{this.props.okText}</Button>
           </div>
         </div>
       </Modal>

--- a/packages/cancelable-edit/index.jsx
+++ b/packages/cancelable-edit/index.jsx
@@ -103,6 +103,7 @@ module.exports = React.createClass({
 
   handleCancel() {
     if (this.unsaved()) {
+      this.refs.input.getDOMNode().blur();
       this.setState({showAlert: true});
     } else {
       this.setState({editing: false});

--- a/packages/modal/index.jsx
+++ b/packages/modal/index.jsx
@@ -35,15 +35,15 @@ module.exports = React.createClass({
 
   layerDidMount() {
     animationCallback(this._layer.querySelector('.Modal-dialog'), this.setVisibleState);
-    window.addEventListener('keyup', this.handleKeyUp);
+    window.addEventListener('keydown', this.handleKeyDown);
   },
 
   layerWillUnmount() {
-    window.removeEventListener('keyup', this.handleKeyUp);
+    window.removeEventListener('keydown', this.handleKeyDown);
     document.body.classList.remove('isUnscrollable');
   },
 
-  handleKeyUp(e) {
+  handleKeyDown(e) {
     if (e.keyCode === 27) {
       this.handleClose();
     }


### PR DESCRIPTION
Makes hotkey handling more consistent.
This may break bad consumers that listen to internal KeyUp events.
One of those consumers is the alert dialog box, which now instead of using Modal internal sets focus on the OK button by default (this does not break dialogs such as Prompt since they have their own focusing code that overrides this.).
Cancellable Edit blurs on cancel now, to avoid blocking hotkeys on other dialogs.