### PR TITLE
Add docs for ActionsBar and AppHeader

### DIFF
--- a/app/index.jsx
+++ b/app/index.jsx
@@ -37,19 +37,30 @@ const packages = _.map(packageRequire.keys(), path => {
 function wrapPackage(component) {
   const Example = packageRequire(component.path);
 
-  return (
-    <div className="Playground-Example" key={component.name}>
-      <h2 id={component.name}>{component.friendlyName} ({component.name})</h2>
-      {component.readme && <div className="Playground-Example-Sheet Playground-Example-Sheet--Readme">
+  var readme = component.readme
+    ? <div className="Playground-Example-Sheet Playground-Example-Sheet--Readme">
         <h3>Readme</h3>
         <article className="Playground-Example-Sheet-Body" dangerouslySetInnerHTML={{__html: component.readme}}></article>
-      </div>}
+      </div>
+    : null;
+  var wide = Example.wide === true;
+
+  var exampleClass = React.addons.classSet({
+    'Playground-Example': true,
+    'Playground-Example--wide': wide,
+  });
+
+  return (
+    <div className={exampleClass} key={component.name}>
+      <h2 id={component.name}>{component.friendlyName} ({component.name})</h2>
+      {wide || readme}
       <div className="Playground-Example-Sheet Playground-Example-Sheet--Demo">
         <h3>Example</h3>
         <div className="Playground-Example-Sheet-Body">
           <Example />
         </div>
       </div>
+      {wide && readme}
     </div>
   );
 }

--- a/app/index.scss
+++ b/app/index.scss
@@ -101,32 +101,36 @@ code {
     }
   }
 
-  @media (min-width: 700px) {
+  &:not(.Playground-Example--wide) {
 
-    .Playground-Example-Sheet {
-      padding-right: .5em;
+    @media (min-width: 700px) {
+
+      .Playground-Example-Sheet--Readme {
+        padding-right: .5em;
+      }
+
+      .Playground-Example-Sheet--Readme, .Playground-Example-Sheet--Readme + .Playground-Example-Sheet--Demo {
+        width: 50%;
+        display: inline-block;
+        vertical-align: top;
+      }
+
+      .Playground-Example-Sheet--Readme + .Playground-Example-Sheet--Demo {
+        padding-left: .5em;
+      }
+
     }
 
-    .Playground-Example-Sheet--Readme, .Playground-Example-Sheet--Readme + .Playground-Example-Sheet--Demo {
-      width: 50%;
-      display: inline-block;
-      vertical-align: top;
+    @media (min-width: 900px) {
+      .Playground-Example-Sheet--Readme {
+        width: 60%;
+      }
+
+      .Playground-Example-Sheet--Readme + .Playground-Example-Sheet--Demo {
+        width: 40%;
+      }
     }
 
-    .Playground-Example-Sheet--Readme + .Playground-Example-Sheet--Demo {
-      padding-left: .5em;
-    }
-
-  }
-
-  @media (min-width: 900px) {
-    .Playground-Example-Sheet--Readme {
-      width: 60%;
-    }
-
-    .Playground-Example-Sheet--Readme + .Playground-Example-Sheet--Demo {
-      width: 40%;
-    }
   }
 
   &:last-child {

--- a/packages/actions-bar/README.md
+++ b/packages/actions-bar/README.md
@@ -1,0 +1,52 @@
+# ActionsBar
+
+Application toolbar with two nav sections and a title.
+
+## Usage
+
+```
+<ActionsBar
+  title="Actions Bar"
+  links={[
+    <span key={1} className={ActionsBar.NAVIGATION_TITLE_CLASSNAME}>SECTION:</span>,
+    <a key={2} href="#" className={`${ActionsBar.NAVIGATION_ITEM_CLASSNAME} active`}>First</a>,
+    <a key={3} href="#" className={ActionsBar.NAVIGATION_ITEM_CLASSNAME}>Second</a>
+  ]}
+  actions={[
+    <a key={1} href="#" className={ActionsBar.ACTION_ITEM_CLASSNAME}><Icon type="plus" font={false} /></a>,
+    <input key={2} className={ActionsBar.ACTION_SEARCH_CLASSNAME} type="text" />
+  ]}
+/>
+```
+
+## Properties
+
+### `title`
+
+Title to display in the bar.
+
+### `links`
+
+Array of elements, or element to display as tab-like buttons on the left of the bar.
+
+### `actions`
+
+Array of elements, or element to display as buttons on the right of the bar.
+
+## Static Properties
+
+### `NAVIGATION_ITEM_CLASSNAME`
+
+Class name suitable for `<a>` elements to be displayed in the `links` section.
+
+### `NAVIGATION_TITLE_CLASSNAME`
+
+Class name suitable for a subtitle to be display in the `links` section.
+
+### `ACTION_ITEM_CLASSNAME`
+
+Class name suitable for `<a>` elements displayed in the `actions` section.
+
+### `ACTION_SEARCH_CLASSNAME`
+
+Class name suitable for `<input>` elements displayed in the `actions` section.

--- a/packages/actions-bar/example.jsx
+++ b/packages/actions-bar/example.jsx
@@ -8,6 +8,10 @@ const Icon = require('../icon');
 module.exports = React.createClass({
   displayName: 'ActionsBarExample',
 
+  statics: {
+    wide: true,
+  },
+
   title() {
     return 'Action Bar';
   },

--- a/packages/app-header/README.md
+++ b/packages/app-header/README.md
@@ -1,0 +1,35 @@
+# AppHeader
+
+Application header with two nav sections and a title.
+
+## Usage
+
+```
+<AppHeader
+  title="App Header"
+  navLeft={
+    <span>
+      <a href="#" className="AppHeader-link">Home</a>
+    </span>
+  }
+  navRight={
+    <span>
+      <a href="#" className="AppHeader-link">Search</a>
+    </span>
+  }
+/>
+```
+
+## Properties
+
+### `title`
+
+Title to display in the bar.
+
+### `navLeft`
+
+Element to display as on the left of the bar.
+
+### `navRight`
+
+Element to display on the right of the bar.

--- a/packages/app-header/example.jsx
+++ b/packages/app-header/example.jsx
@@ -7,6 +7,10 @@ const AppHeader = require('./');
 module.exports = React.createClass({
   displayName: 'AppHeaderExample',
 
+  statics: {
+    wide: true,
+  },
+
   render() {
     return (
       <AppHeader

--- a/packages/card/example.jsx
+++ b/packages/card/example.jsx
@@ -9,6 +9,10 @@ require('./example.scss');
 module.exports = React.createClass({
   displayName: 'CardExample',
 
+  statics: {
+    wide: true,
+  },
+
   render() {
     return (
       <div className="CardContainer">

--- a/packages/table/example.jsx
+++ b/packages/table/example.jsx
@@ -49,6 +49,10 @@ const data = [
 module.exports = React.createClass({
   displayName: 'TableExample',
 
+  statics: {
+    wide: true,
+  },
+
   render() {
     return (
       <Table


### PR DESCRIPTION
Also allow for a `wide` example display mode, wherein examples render above their documentation. This is intended only for elements whose width is much greater than their height, or which render incorrectly at comparatively small sizes relative to the viewport.