### PR TITLE
Add SuitClassSet, a replacement for classSet

### DIFF
--- a/app/index.jsx
+++ b/app/index.jsx
@@ -6,6 +6,7 @@ const Router = require('react-router');
 const Route = Router.Route;
 const Link = Router.Link;
 const RouteHandler = Router.RouteHandler;
+const SuitClassSet = require('../packages/suit-class-set');
 
 require('open-sans/scss/open-sans.scss');
 require('normalize.css/normalize.css');
@@ -37,26 +38,27 @@ const packages = _.map(packageRequire.keys(), path => {
 function wrapPackage(component) {
   const Example = packageRequire(component.path);
 
-  var readme = component.readme
-    ? <div className="Playground-Example-Sheet Playground-Example-Sheet--Readme">
+  const readme = component.readme
+    ? <div className="PlaygroundExample-sheet PlaygroundExample-sheet--readme">
         <h3>Readme</h3>
-        <article className="Playground-Example-Sheet-Body" dangerouslySetInnerHTML={{__html: component.readme}}></article>
+        <article className="PlaygroundExample-sheet-body" dangerouslySetInnerHTML={{__html: component.readme}}></article>
       </div>
     : null;
-  var wide = Example.wide === true;
+  const wide = Example.wide === true;
 
-  var exampleClass = React.addons.classSet({
-    'Playground-Example': true,
-    'Playground-Example--wide': wide,
+  const exampleClass = new SuitClassSet('PlaygroundExample');
+
+  exampleClass.addModifier({
+    wide,
   });
 
   return (
-    <div className={exampleClass} key={component.name}>
+    <div className={exampleClass.toString()} key={component.name}>
       <h2 id={component.name}>{component.friendlyName} ({component.name})</h2>
       {wide || readme}
-      <div className="Playground-Example-Sheet Playground-Example-Sheet--Demo">
+      <div className="PlaygroundExample-sheet PlaygroundExample-sheet--demo">
         <h3>Example</h3>
-        <div className="Playground-Example-Sheet-Body">
+        <div className="PlaygroundExample-sheet-body">
           <Example />
         </div>
       </div>
@@ -72,7 +74,7 @@ const App = React.createClass({
     return (
       <div>
         <h1>Macropod Components</h1>
-        <ul className="Playground-TOC">
+        <ul className="PlaygroundTOC">
           <li><Link to="/">All</Link></li>
           {packages.map(component => <li key={component.path}><Link to={`/${component.name}`}>{component.friendlyName}</Link></li>)}
         </ul>

--- a/app/index.scss
+++ b/app/index.scss
@@ -40,7 +40,7 @@ code {
   border-radius: 3px;
 }
 
-.Playground-TOC {
+.PlaygroundTOC {
   column-width: 12em;
   padding: 0;
   list-style: none;
@@ -67,13 +67,13 @@ code {
   }
 }
 
-.Playground-Example {
+.PlaygroundExample {
   box-sizing: border-box;
   margin: 0;
   padding-bottom: 1.5em;
   border-bottom: 1px solid #ccc;
 
-  .Playground-Example-Sheet {
+  .PlaygroundExample-sheet {
     margin-bottom: 1em;
     > h3 {
       background-color: #f5f5f5;
@@ -86,7 +86,7 @@ code {
       line-height: 17px;
       display: block;
     }
-    .Playground-Example-Sheet-Body {
+    .PlaygroundExample-sheet-body {
       background-color: #fff;
       border: 1px solid #ddd;
       border-bottom-left-radius: 3px;
@@ -95,38 +95,38 @@ code {
     }
   }
 
-  .Playground-Example-Sheet-Body {
+  .PlaygroundExample-sheet-body {
     & > :first-child {
       margin-top: 0;
     }
   }
 
-  &:not(.Playground-Example--wide) {
+  &:not(.PlaygroundExample--wide) {
 
     @media (min-width: 700px) {
 
-      .Playground-Example-Sheet--Readme {
+      .PlaygroundExample-sheet--readme {
         padding-right: .5em;
       }
 
-      .Playground-Example-Sheet--Readme, .Playground-Example-Sheet--Readme + .Playground-Example-Sheet--Demo {
+      .PlaygroundExample-sheet--readme, .PlaygroundExample-sheet--readme + .PlaygroundExample-sheet--demo {
         width: 50%;
         display: inline-block;
         vertical-align: top;
       }
 
-      .Playground-Example-Sheet--Readme + .Playground-Example-Sheet--Demo {
+      .PlaygroundExample-sheet--readme + .PlaygroundExample-sheet--demo {
         padding-left: .5em;
       }
 
     }
 
     @media (min-width: 900px) {
-      .Playground-Example-Sheet--Readme {
+      .PlaygroundExample-sheet--readme {
         width: 60%;
       }
 
-      .Playground-Example-Sheet--Readme + .Playground-Example-Sheet--Demo {
+      .PlaygroundExample-sheet--readme + .PlaygroundExample-sheet--demo {
         width: 40%;
       }
     }

--- a/packages/avatar-with-pie/index.jsx
+++ b/packages/avatar-with-pie/index.jsx
@@ -3,6 +3,7 @@
 const React = require('react/addons');
 const Avatar = require('../avatar');
 const PieBadge = require('../pie-badge');
+const SuitClassSet = require('../suit-class-set');
 
 require('./avatar-with-pie.scss');
 
@@ -25,15 +26,12 @@ module.exports = React.createClass({
   },
 
   render() {
-    const classes = {
-      'AvatarWithPie': true,
-      [`AvatarWithPie--${this.props.size}`]: true,
-    };
+    const containerClass = new SuitClassSet('AvatarWithPie');
 
-    const containerClass = React.addons.classSet(classes);
+    containerClass.addModifier(this.props.size);
 
     return (
-      <span className={containerClass}>
+      <span className={containerClass.toString()}>
         <Avatar
           size={this.props.size}
           firstName={this.props.firstName}

--- a/packages/avatar/index.jsx
+++ b/packages/avatar/index.jsx
@@ -3,6 +3,7 @@
 const md5 = require('MD5');
 const React = require('react/addons');
 const keyMirror = require('react/lib/keyMirror');
+const SuitClassSet = require('../suit-class-set');
 const _ = require('lodash-node');
 
 require('./avatar.scss');
@@ -95,13 +96,12 @@ module.exports = React.createClass({
       }
     }
 
-    const classSet = React.addons.classSet;
+    const containerClass = new SuitClassSet('Avatar');
 
-    const containerClass = classSet({
-      'Avatar': true,
-      'Avatar--circle': !!this.props.circle,
-      'Avatar--bordered': !!src,
-      [`Avatar--${this.props.size}`]: true,
+    containerClass.addModifier({
+      'circle': !!this.props.circle,
+      'bordered': !!src,
+      [this.props.size]: true,
     });
 
     firstName = this.props.title || firstName;
@@ -109,7 +109,7 @@ module.exports = React.createClass({
 
     return (
       <span title={`${firstName}’s avatar`}
-        className={containerClass}
+        className={containerClass.toString()}
         style={{backgroundColor: this.getColor(firstName + lastName)}}>
         <span className="Avatar-initials" aria-hidden="true">{this.getInitials(firstName, lastName)}</span>
         <span className="Avatar-image" aria-hidden="true" style={{backgroundImage: this.getBackgroundImage(src, email)}}></span>

--- a/packages/button/index.jsx
+++ b/packages/button/index.jsx
@@ -3,7 +3,7 @@
 require('./button.scss');
 
 const React = require('react/addons');
-const classSet = React.addons.classSet;
+const SuitClassSet = require('../suit-class-set');
 const _ = require('lodash-node');
 
 const validTypes = [
@@ -43,19 +43,19 @@ module.exports = React.createClass({
   },
 
   render() {
-    const buttonClass = classSet({
-      'Button': true,
-      'Button--small': this.props.small,
-      'Button--skeleton': this.props.skeleton,
-      'Button--success': this.props.success,
-      'Button--cancel': this.props.cancel,
-      'Button--danger': this.props.danger,
-      [`Button--${this.props.type}`]: !!this.props.type,
-      [this.props.className]: !!this.props.className,
+    const buttonClass = new SuitClassSet('Button');
+
+    buttonClass.addModifier({
+      'small': !!this.props.small,
+      'skeleton': !!this.props.skeleton,
+      'success': !!this.props.success,
+      'cancel': !!this.props.cancel,
+      'danger': !!this.props.danger,
+      [this.props.type]: !!this.props.type,
     });
 
     return (
-      <button {...this.props} className={buttonClass}>{this.props.children}</button>
+      <button {...this.props} className={buttonClass.toString() + (this.props.className ? ` ${this.props.className}` : '')}>{this.props.children}</button>
     );
   }
 });

--- a/packages/cancelable-edit/index.jsx
+++ b/packages/cancelable-edit/index.jsx
@@ -4,6 +4,7 @@ const AutoSizeTextArea = require('react-textarea-autosize');
 const Alert = require('../alert');
 const Button = require('../button');
 const KeyMixin = require('../key-mixin');
+const SuitClassSet = require('../suit-class-set');
 
 require('./style');
 
@@ -152,11 +153,15 @@ module.exports = React.createClass({
     this.focus();
   },
 
-  renderContent() {
-    const editClassName = React.addons.classSet({
-      'CancelableEdit-edit': true,
-      'is-editing': this.state.editing,
-      'CancelableEdit-edit--em': this.props.em,
+  renderContent(parentClassName) {
+    const editClassName = parentClassName.createDescendent('edit');
+
+    editClassName.addModifier({
+      'em': this.props.em,
+    });
+
+    editClassName.addState({
+      'editing': this.state.editing,
     });
 
     if (this.props.creating && !this.state.editing) {
@@ -188,15 +193,15 @@ module.exports = React.createClass({
   },
 
   render() {
-    const className = React.addons.classSet({
-      [this.props.className]: !!this.props.className,
-      'CancelableEdit': true,
-      'CancelableEdit--inline': this.props.inline,
+    const className = new SuitClassSet('CancelableEdit');
+
+    className.addModifier({
+      'inline': this.props.inline,
     });
 
     return (
-      <div className={className}>
-        { this.renderContent() }
+      <div className={className.toString() + (this.props.className ? ` ${this.props.className}` : '')}>
+        { this.renderContent(className) }
         { this.state.editing &&
           <div className="CancelableEdit-control">
             <Button

--- a/packages/comments/comment.jsx
+++ b/packages/comments/comment.jsx
@@ -2,7 +2,7 @@
 const React = require('react/addons');
 const _ = require('lodash-node');
 const Textarea = require('react-textarea-autosize');
-const classSet = React.addons.classSet;
+const SuitClassSet = require('../suit-class-set');
 
 const DropdownMenu = require('../dropdown-menu');
 const Avatar = require('../avatar');
@@ -138,11 +138,12 @@ module.exports = React.createClass({
   },
 
   render() {
-    let commentClass = classSet({
-      'Comment': true,
-      'Comment--starred': this.state.stared,
-      'Comment--inputButtons': this.props.inputButtons,
-      'Comment--repliable': this.props.comment.isDiscussion === false && this.props.comment.repliable === false
+    const commentClass = new SuitClassSet('Comment');
+
+    commentClass.addModifier({
+      'starred': this.state.stared,
+      'inputButtons': this.props.inputButtons,
+      'repliable': this.props.comment.isDiscussion === false && this.props.comment.repliable === false,
     });
 
     const replies = _.clone(this.props.replies).reverse();
@@ -174,7 +175,7 @@ module.exports = React.createClass({
     }
 
     return (
-      <div className={commentClass}>
+      <div className={commentClass.toString()}>
 
         {dropdownContent}
 

--- a/packages/covert-header/index.jsx
+++ b/packages/covert-header/index.jsx
@@ -23,6 +23,7 @@ const React = require('react/addons');
 
 require('./covert-header.scss');
 const ScrollEvent = require('../scroll-event-mixin');
+const SuitClassSet = require('../suit-class-set');
 
 module.exports = React.createClass({
   displayName: 'CovertHeader',
@@ -44,14 +45,14 @@ module.exports = React.createClass({
   },
 
   render() {
-    const classSet = React.addons.classSet;
-    const covertHeaderClass = classSet({
-      'CovertHeader': true,
-      'CovertHeader--hide': this.state.hide
+    const covertHeaderClass = new SuitClassSet('CovertHeader');
+
+    covertHeaderClass.addModifier({
+      'hide': this.state.hide
     });
 
     return (
-      <header {...this.props} className={covertHeaderClass} ref="header">
+      <header {...this.props} className={covertHeaderClass.toString()} ref="header">
         {this.props.children}
       </header>
     );

--- a/packages/delete-button/index.jsx
+++ b/packages/delete-button/index.jsx
@@ -8,13 +8,8 @@ module.exports = React.createClass({
   displayName: 'DeleteButton',
 
   render() {
-    const className = React.addons.classSet({
-      'DeleteButton': true,
-      [this.props.className]: !!this.props.className,
-    });
-
     return (
-      <button {...this.props} className={className}>
+      <button {...this.props} className={'DeleteButton' + (this.props.className ? ` ${this.props.className}` : '')}>
         ×
       </button>
     );

--- a/packages/dropdown-menu/index.jsx
+++ b/packages/dropdown-menu/index.jsx
@@ -1,6 +1,7 @@
 'use strict';
 const React = require('react/addons');
 const Popover = require('../popover');
+const SuitClassSet = require('../suit-class-set');
 require('./dropdown-menu.scss');
 
 module.exports = React.createClass({
@@ -12,16 +13,15 @@ module.exports = React.createClass({
   },
 
   render() {
+    const dropdownMenuClass = new SuitClassSet('DropdownMenu');
 
-    const dropdownMenuClass = React.addons.classSet({
-      'DropdownMenu': true,
-      'DropdownMenu--withFooter': !!this.props.footer,
-      'DroddownMenu--alignRight': this.props.align === 'right',
-      [this.props.className]: true,
+    dropdownMenuClass.addModifier({
+      'withFooter': !!this.props.footer,
+      'alignRight': this.props.align === 'right',
     });
 
     return (
-      <Popover {...this.props} className={dropdownMenuClass} align={this.props.align}>
+      <Popover {...this.props} className={dropdownMenuClass.toString() + (this.props.className ? ` ${this.props.className}` : '')} align={this.props.align}>
         <div className="DropdownMenu-internal">
           {this.props.children}
 

--- a/packages/icon/index.jsx
+++ b/packages/icon/index.jsx
@@ -1,7 +1,6 @@
 'use strict';
 
 const React = require('react/addons');
-const classSet = React.addons.classSet;
 const _ = require('lodash-node');
 const keyMirror = require('react/lib/keyMirror');
 
@@ -30,20 +29,12 @@ module.exports = React.createClass({
   },
 
   render() {
-    let classes = {
-      'Icon': true,
-    };
-    classes[this.props.className] = !!this.props.className; // es6 {[whatever]: true} syntax not supported yet
-    let className = classSet(classes);
-
-    let props = {
-      className: className,
+    return this.props.component({
+      className: 'Icon' + (this.props.className ? ` ${this.props.className}` : ''),
       style: this.props.style,
       dangerouslySetInnerHTML: {
         __html: require(`!raw!./svgs/icon-${this.props.type}.svg`)
       }
-    };
-
-    return this.props.component(props);
+    });
   }
 });

--- a/packages/lightbox/index.jsx
+++ b/packages/lightbox/index.jsx
@@ -2,6 +2,7 @@
 
 const React = require('react/addons');
 const OnResize = require('react-window-mixins').OnResize;
+const SuitClassSet = require('../suit-class-set');
 
 require('./lightbox.scss');
 
@@ -53,14 +54,18 @@ const AssetImage = React.createClass({
   },
 
   render() {
-    const imageClasses = React.addons.classSet({
-      'AssetImage': true,
-      'AssetImage--zoomed': this.state.zoomed,
-      'AssetImage--zoomable': this.state.zoomable
+    const imageClasses = new SuitClassSet('AssetImage');
+
+    imageClasses.addModifier({
+      'zoomable': this.state.zoomable,
+    });
+
+    imageClasses.addState({
+      'zoomed': this.state.zoomed,
     });
 
     return (
-      <img className={imageClasses} src={this.props.asset.path} onClick={this.toggleImageZoom} onLoad={this.handleImageLoad} />
+      <img className={imageClasses.toString()} src={this.props.asset.path} onClick={this.toggleImageZoom} onLoad={this.handleImageLoad} />
     );
   },
 
@@ -240,24 +245,19 @@ const Lightbox = React.createClass({
 
     const multipleAssets = this.props.assets.length > 1;
 
-    const lightboxClassObject = {
-      'Lightbox': true,
-      'Lightbox--multiple': multipleAssets,
-      'Lightbox--fullscreen': !!this.props.fullscreen
-    };
+    const lightboxClass = new SuitClassSet('Lightbox');
 
-    if (typeof this.props.className === 'string') {
-      lightboxClassObject[this.props.className] = true;
-    }
-
-    const lightboxClass = React.addons.classSet(lightboxClassObject);
+    lightboxClass.addModifier({
+      'multiple': multipleAssets,
+      'fullscreen': !!this.props.fullscreen
+    });
 
     let currentAsset = this.getCurrentAsset();
 
     const Container = Lightbox.containerFor(currentAsset.media);
 
     return (
-      <div className={lightboxClass} style={this.props.style}>
+      <div className={lightboxClass.toString() + (this.props.className ? ` ${this.props.className}` : '')} style={this.props.style}>
         <div className="Lightbox-asset">
 
           <div className="Lightbox-details">

--- a/packages/lightbox/lightbox.scss
+++ b/packages/lightbox/lightbox.scss
@@ -56,12 +56,12 @@ $checkerboard-size: 10px;
         &.AssetImage--zoomable {
           cursor: zoom-in;
 
-          &.AssetImage--zoomed {
+          &.is-zoomed {
             cursor: zoom-out;
           }
         }
 
-        &.AssetImage--zoomed {
+        &.is-zoomed {
           max-width: none;
           max-height: none;
         }

--- a/packages/loading/index.jsx
+++ b/packages/loading/index.jsx
@@ -1,6 +1,7 @@
 'use strict';
 
 const React = require('react/addons');
+const SuitClassSet = require('../suit-class-set');
 require('./loading.scss');
 
 module.exports = React.createClass({
@@ -13,13 +14,14 @@ module.exports = React.createClass({
   },
 
   render() {
-    const classes = React.addons.classSet({
-      'Loading': true,
-      'Loading--small': this.props.size === 'small'
+    const classes = new SuitClassSet('Loading');
+
+    classes.addModifier({
+      'small': this.props.size === 'small'
     });
 
     return (
-      <div className={classes}>
+      <div className={classes.toString()}>
       {(this.props.type === 'stack') &&
         <svg className="Loading--stack" version="1.1" viewBox="0 0 600 600">
           <path className="Loading-top Loading-main" clip-rule="evenodd" d="M561.5,119H181.1c-5.2,0-10.4-0.6-19.4,6.1L48,209.5c-9,6.8-2.6,12.3,2.6,12.3h385.1c5.2,0,15.1-1.4,24.1-8.2l109-82.3C577.8,124.5,566.7,119,561.5,119z" />

--- a/packages/modal/index.jsx
+++ b/packages/modal/index.jsx
@@ -4,6 +4,7 @@ const React = require('react/addons');
 const LayeredComponentMixin = require('react-components/js/layered-component-mixin');
 
 const animationCallback = require('../style-utilities').animationCallback;
+const SuitClassSet = require('../suit-class-set');
 
 require('./modal.scss');
 
@@ -75,32 +76,23 @@ module.exports = React.createClass({
   },
 
   renderLayer() {
-    const classSet = React.addons.classSet;
-    const modalClasses = {
-      'Modal': true,
-      'Modal--visible': this.state.showModal,
-      'Modal--invisible': !this.state.showModal
-    };
+    const modalClasses = new SuitClassSet('Modal');
 
-    if (this.props.className) {
-      modalClasses[this.props.className] = true;
-    }
+    modalClasses.addModifier({
+      'visible': this.state.showModal,
+      'invisible': !this.state.showModal
+    });
 
-    const modalClassName = classSet(modalClasses);
+    const dialogClasses = modalClasses.createDescendent('dialog');
 
-    const dialogClassObject = {
-      'Modal-dialog': true,
-      'Modal-dialog--withHeader': this.props.title,
-      'Modal-dialog--withFooter': this.props.footer,
-      [this.props.dialogClassName]:
-        (typeof this.props.dialogClassName === 'string'),
-    };
-
-    const dialogClassName = classSet(dialogClassObject);
+    dialogClasses.addModifier({
+      'withHeader': this.props.title,
+      'withFooter': this.props.footer,
+    });
 
     return (
-      <div className={modalClassName} onClick={this.handleClose} onScroll={this.stopPropagation}>
-        <div className={dialogClassName} onClick={this.stopPropagation} style={{maxWidth: this.props.maxWidth, maxHeight: this.props.maxHeight}}>
+      <div className={modalClasses.toString() + (this.props.className ? ` ${this.props.className}` : '')} onClick={this.handleClose} onScroll={this.stopPropagation}>
+        <div className={dialogClasses.toString() + (this.props.dialogClassName ? ` ${this.props.dialogClassName}` : '')} onClick={this.stopPropagation} style={{maxWidth: this.props.maxWidth, maxHeight: this.props.maxHeight}}>
           {this.props.closeButton &&
             <a className="Modal-close" href="#" onClick={this.handleClose}> &#215; </a>
           }

--- a/packages/pie-badge/index.jsx
+++ b/packages/pie-badge/index.jsx
@@ -1,6 +1,7 @@
 'use strict';
 
 const React = require('react/addons');
+const SuitClassSet = require('../suit-class-set');
 
 require('./pie-badge.scss');
 
@@ -29,13 +30,14 @@ module.exports = React.createClass({
 
     const complete = this.props.total > 0 && this.props.complete >= this.props.total;
 
-    const pieBadgeClasses = React.addons.classSet({
-      'PieBadge': true,
-      'PieBadge--complete': complete
+    const pieBadgeClasses = new SuitClassSet('PieBadge');
+
+    pieBadgeClasses.addState({
+      complete
     });
 
     return (
-      <svg className={pieBadgeClasses} version="1.1" viewBox="0 0 32 32">
+      <svg className={pieBadgeClasses.toString()} version="1.1" viewBox="0 0 32 32">
         <circle cx="16" cy="16" r="14.5" stroke={this.props.backgroundColor} />
         {this.props.total > 0 && this.props.total >= this.props.complete && <path className="PieBadge-pie" d={pathDefinition} />}
         {complete && <path className="PieBadge-check" d="M13.188 19.341l-3.984-3.926c-.43-.43-.869-.43-1.318 0-.449.43-.439.859.029 1.289l4.477 4.443c.495.553 1.07.63 1.525.108l9.409-9.415c.43-.43.42-.869-.029-1.318-.449-.449-.889-.459-1.318-.029l-8.791 8.847z"/>}

--- a/packages/pie-badge/pie-badge.scss
+++ b/packages/pie-badge/pie-badge.scss
@@ -8,7 +8,7 @@ $color-pie: #a7cd45;
     stroke-width: 3px;
   }
 
-  &.PieBadge--complete {
+  &.is-complete {
     circle {
       fill: $color-pie;
     }

--- a/packages/steps/index.jsx
+++ b/packages/steps/index.jsx
@@ -1,6 +1,7 @@
 'use strict';
 
 const React = require('react/addons');
+const SuitClassSet = require('../suit-class-set');
 
 require('./steps.scss');
 
@@ -11,12 +12,13 @@ module.exports = React.createClass({
     const children = [];
 
     for (let i = 0; i < this.props.count; i++) {
-      const classes = React.addons.classSet({
-        'Steps-step': true,
-        'is-active': i === this.props.current - 1,
+      const classes = new SuitClassSet('Steps-step');
+
+      classes.addState({
+        'active': i === this.props.current - 1,
       });
 
-      children.push(<span key={i} className={classes}>{i + 1}</span>);
+      children.push(<span key={i} className={classes.toString()}>{i + 1}</span>);
     }
 
     return (

--- a/packages/suit-class-set/README.md
+++ b/packages/suit-class-set/README.md
@@ -1,0 +1,59 @@
+# SuitClassSet
+
+Class property formatter based on, and enforcing the [SUIT CSS naming conventions](https://github.com/suitcss/suit/blob/cb2adfea6ad26a2c6af9f2c1bc880e966854e709/doc/naming-conventions.md).
+
+## Usage
+
+```javascript
+const elementClasses = new SuitClassSet('MyComponent');
+
+elementClasses.addModifier('foo');
+
+elementClasses.addState('bar');
+
+elementClasses.addUtility('baz');
+
+element.class = elementClasses.toString();
+```
+
+## Constructor
+
+Creates a new SuitClassSet instance, and sets the component name, from which each class name will be derived.
+
+## Methods
+
+### `add` methods
+
+Each of the `add` methods accepts and number of arguments, each in the following formats;
+
+* A `string` representing a single class.
+* An `Array`, with each item being a `string` representing a single class.
+* A plain `Object`, whose enumerable keys represent a single class. If a key's associated value is falsy, the class will be excluded from output.
+
+_**Note**: at present camel/snake case for each type of name is not required, but that may become the case in the future. Please follow the rules in the SUIT CSS naming conventions as closely as possible._
+
+#### `addModifier`
+
+Adds a [Modifier](https://github.com/suitcss/suit/blob/cb2adfea6ad26a2c6af9f2c1bc880e966854e709/doc/naming-conventions.md#componentname--modifiername) class to the set. For example, adding `'foo'` would add a class called `'MyComponent--foo'`.
+
+#### `addState`
+
+Adds a [State](https://github.com/suitcss/suit/blob/cb2adfea6ad26a2c6af9f2c1bc880e966854e709/doc/naming-conventions.md#componentnameis-stateofcomponent) class to the set. For example, adding `'bar'` would add a class called `'is-bar'`.
+
+#### `addUtility`
+
+Adds a [Utility](https://github.com/suitcss/suit/blob/cb2adfea6ad26a2c6af9f2c1bc880e966854e709/doc/naming-conventions.md#u-utilityname) class to the set. For example, adding `'baz'` would add a class called `'u-baz'`.
+
+### `createDescendent`
+
+Creates a new `SuitClassSet` instance for a [descendent](https://github.com/suitcss/suit/blob/cb2adfea6ad26a2c6af9f2c1bc880e966854e709/doc/naming-conventions.md#componentname-descendentname) of the current one.
+
+Accepts one argument, which is the descendent name. For example, calling `createDescendent` with `bar` would create a new `SuitClassSet` instance whose base component name is `MyComponent-bar`.
+
+### `toArray`
+
+Generates an array of class name strings based on the current state of the set.
+
+### `toString`
+
+Returns all class names as one string, suitable for use in DOM `class`, or React `className` properties.

--- a/packages/suit-class-set/example.jsx
+++ b/packages/suit-class-set/example.jsx
@@ -7,6 +7,10 @@ const SuitClassSet = require('./');
 module.exports = React.createClass({
   displayName: 'SuitClassSet-example',
 
+  statics: {
+    wide: true,
+  },
+
   render() {
     const aClassSet = new SuitClassSet('SuitClassSet');
     const aDescendentClassSet = aClassSet.createDescendent('descendent');

--- a/packages/suit-class-set/example.jsx
+++ b/packages/suit-class-set/example.jsx
@@ -1,0 +1,45 @@
+'use strict';
+
+const React = require('react');
+
+const SuitClassSet = require('./');
+
+module.exports = React.createClass({
+  displayName: 'SuitClassSet-example',
+
+  render() {
+    const aClassSet = new SuitClassSet('SuitClassSet');
+    const aDescendentClassSet = aClassSet.createDescendent('descendent');
+
+    aClassSet.addModifier('foo');
+
+    aClassSet.addModifier({
+      'bar': true,
+      'baz': false,
+      'something with spaces which should not work': true,
+    });
+
+    aClassSet.addModifier([
+      'abc',
+      '123',
+    ]);
+
+    aClassSet.addState('loading');
+
+    aDescendentClassSet.addModifier('withModifier');
+
+    return (
+      <div>
+        <p>This example contains two SuitClassSets; one demonstrating all the modifier and state features, and one which is a descendent whose class name is derived from the first.</p>
+        <h3><code>aClassSet</code></h3>
+        <pre>
+          {aClassSet.toString()}
+        </pre>
+        <h3><code>aDescendentClassSet</code></h3>
+        <pre>
+          {aDescendentClassSet.toString()}
+        </pre>
+      </div>
+    );
+  }
+});

--- a/packages/suit-class-set/example.jsx
+++ b/packages/suit-class-set/example.jsx
@@ -28,6 +28,8 @@ module.exports = React.createClass({
 
     aDescendentClassSet.addModifier('withModifier');
 
+    aDescendentClassSet.addUtility('clearFix');
+
     return (
       <div>
         <p>This example contains two SuitClassSets; one demonstrating all the modifier and state features, and one which is a descendent whose class name is derived from the first.</p>

--- a/packages/suit-class-set/index.js
+++ b/packages/suit-class-set/index.js
@@ -20,13 +20,18 @@ function SuitClassSet(componentName) {
 
     modifiers: {
       value: [],
-      writable: true
+      writable: true,
     },
 
     states: {
       value: [],
-      writable: true
-    }
+      writable: true,
+    },
+
+    utilities: {
+      value: [],
+      writable: true,
+    },
 
   });
 }
@@ -82,6 +87,10 @@ SuitClassSet.prototype.addState = function() {
   this.add('states', arguments);
 };
 
+SuitClassSet.prototype.addUtility = function() {
+  this.add('utilities', arguments);
+}
+
 SuitClassSet.prototype.createDescendent = function(descendentName) {
   if (!isValidString(descendentName)) {
     throw new Error(`Supplied descendent name "${descendentName}" is invalid.`);
@@ -97,6 +106,13 @@ SuitClassSet.prototype.toArray = function() {
         .uniq()
         .filter(subClass => subClass.length > 0)
         .map(subClass => [this.componentName, subClass].join(doubleDash))
+        .value()
+    )
+    .concat(
+      _(this.utilities)
+        .uniq()
+        .filter(utility => utility.length > 0)
+        .map(utility => `u-${utility}`)
         .value()
     )
     .concat(

--- a/packages/suit-class-set/index.js
+++ b/packages/suit-class-set/index.js
@@ -6,36 +6,6 @@ const space = ' ';
 const dash = '-';
 const doubleDash = dash+dash;
 
-function SuitClassSet(componentName) {
-  if (!isValidString(componentName)) {
-    throw new Error(`Supplied primary class name "${componentName}" is invalid.`);
-  }
-
-  Object.defineProperties(this, {
-
-    componentName: {
-      configurable: true,
-      value: componentName,
-    },
-
-    modifiers: {
-      value: [],
-      writable: true,
-    },
-
-    states: {
-      value: [],
-      writable: true,
-    },
-
-    utilities: {
-      value: [],
-      writable: true,
-    },
-
-  });
-}
-
 function isValidString(string) {
   return _.isString(string) && string.indexOf(space) === -1;
 }
@@ -53,8 +23,20 @@ function processString(string) {
   }
 }
 
-Object.defineProperty(SuitClassSet.prototype, 'add', {
-  value: function(collection, args) {
+class SuitClassSet {
+
+  constructor(componentName) {
+    if (!isValidString(componentName)) {
+      throw new Error(`Supplied primary class name "${componentName}" is invalid.`);
+    }
+
+    this._componentName = componentName;
+    this._modifiers = [];
+    this._states = [];
+    this._utilities = [];
+  }
+
+  _add(collection, args) {
     Array.prototype.forEach.call(args, arg => {
 
       if (_.isString(arg)) {
@@ -77,55 +59,56 @@ Object.defineProperty(SuitClassSet.prototype, 'add', {
 
     });
   }
-});
 
-SuitClassSet.prototype.addModifier = function() {
-  this.add('modifiers', arguments);
-};
-
-SuitClassSet.prototype.addState = function() {
-  this.add('states', arguments);
-};
-
-SuitClassSet.prototype.addUtility = function() {
-  this.add('utilities', arguments);
-}
-
-SuitClassSet.prototype.createDescendent = function(descendentName) {
-  if (!isValidString(descendentName)) {
-    throw new Error(`Supplied descendent name "${descendentName}" is invalid.`);
+  addModifier() {
+    this._add('_modifiers', arguments);
   }
 
-  return new SuitClassSet([this.componentName, descendentName].join(dash));
-};
+  addState() {
+    this._add('_states', arguments);
+  }
 
-SuitClassSet.prototype.toArray = function() {
-  return [this.componentName]
-    .concat(
-      _(this.modifiers)
-        .uniq()
-        .filter(subClass => subClass.length > 0)
-        .map(subClass => [this.componentName, subClass].join(doubleDash))
-        .value()
-    )
-    .concat(
-      _(this.utilities)
-        .uniq()
-        .filter(utility => utility.length > 0)
-        .map(utility => `u-${utility}`)
-        .value()
-    )
-    .concat(
-      _(this.states)
-        .uniq()
-        .filter(state => state.length > 0)
-        .map(state => `is-${state}`)
-        .value()
-    );
-};
+  addUtility() {
+    this._add('_utilities', arguments);
+  }
 
-SuitClassSet.prototype.toString = function() {
-  return this.toArray().join(space);
-};
+  createDescendent(descendentName) {
+    if (!isValidString(descendentName)) {
+      throw new Error(`Supplied descendent name "${descendentName}" is invalid.`);
+    }
+
+    return new SuitClassSet([this._componentName, descendentName].join(dash));
+  }
+
+  toArray() {
+    return [this._componentName]
+      .concat(
+        _(this._modifiers)
+          .uniq()
+          .filter(subClass => subClass.length > 0)
+          .map(subClass => [this._componentName, subClass].join(doubleDash))
+          .value()
+      )
+      .concat(
+        _(this._utilities)
+          .uniq()
+          .filter(utility => utility.length > 0)
+          .map(utility => `u-${utility}`)
+          .value()
+      )
+      .concat(
+        _(this._states)
+          .uniq()
+          .filter(state => state.length > 0)
+          .map(state => `is-${state}`)
+          .value()
+      );
+  }
+
+  toString() {
+    return this.toArray().join(space);
+  }
+
+}
 
 module.exports = SuitClassSet;

--- a/packages/suit-class-set/index.js
+++ b/packages/suit-class-set/index.js
@@ -1,0 +1,115 @@
+'use strict';
+
+const _ = require('lodash-node');
+const empty = '';
+const space = ' ';
+const dash = '-';
+const doubleDash = dash+dash;
+
+function SuitClassSet(componentName) {
+  if (!isValidString(componentName)) {
+    throw new Error(`Supplied primary class name "${componentName}" is invalid.`);
+  }
+
+  Object.defineProperties(this, {
+
+    componentName: {
+      configurable: true,
+      value: componentName,
+    },
+
+    modifiers: {
+      value: [],
+      writable: true
+    },
+
+    states: {
+      value: [],
+      writable: true
+    }
+
+  });
+}
+
+function isValidString(string) {
+  return _.isString(string) && string.indexOf(space) === -1;
+}
+
+function processString(string) {
+  if (isValidString(string) && string.indexOf(dash) === -1) {
+
+    return string;
+
+  } else {
+
+    console.warn(`Supplied class name fragments must not contain spaces. Ignoring "${string}"`);
+    return empty;
+
+  }
+}
+
+Object.defineProperty(SuitClassSet.prototype, 'add', {
+  value: function(collection, args) {
+    Array.prototype.forEach.call(args, arg => {
+
+      if (_.isString(arg)) {
+        this[collection].push(processString(arg));
+      }
+
+      if (_.isArray(arg)) {
+        this[collection] = this[collection].concat(_.map(arg, item => processString(item)));
+      }
+
+      if (_.isPlainObject(arg)) {
+        this[collection] = this[collection].concat(_(arg).map((item, key) => {
+          if (item) {
+            return processString(key);
+          } else {
+            return empty;
+          }
+        }).value());
+      }
+
+    });
+  }
+});
+
+SuitClassSet.prototype.addModifier = function() {
+  this.add('modifiers', arguments);
+};
+
+SuitClassSet.prototype.addState = function() {
+  this.add('states', arguments);
+};
+
+SuitClassSet.prototype.createDescendent = function(descendentName) {
+  if (!isValidString(descendentName)) {
+    throw new Error(`Supplied descendent name "${descendentName}" is invalid.`);
+  }
+
+  return new SuitClassSet([this.componentName, descendentName].join(dash));
+};
+
+SuitClassSet.prototype.toArray = function() {
+  return [this.componentName]
+    .concat(
+      _(this.modifiers)
+        .uniq()
+        .filter(subClass => subClass.length > 0)
+        .map(subClass => [this.componentName, subClass].join(doubleDash))
+        .value()
+    )
+    .concat(
+      _(this.states)
+        .uniq()
+        .filter(state => state.length > 0)
+        .map(state => `is-${state}`)
+        .value()
+    );
+};
+
+SuitClassSet.prototype.toString = function() {
+  return this.toArray().join(space);
+};
+
+module.exports = SuitClassSet;

--- a/packages/todo/style.scss
+++ b/packages/todo/style.scss
@@ -20,7 +20,7 @@ $color-todo-list-item-border: $color-catskill-white !default;
   margin-right: 24px;
 }
 
-.Todo-listItem-edit{
+.Todo-listItem-edit {
   width: calc(100% - 140px);
 }
 


### PR DESCRIPTION
This move pre-empts React deprecating their `classSet` structure, and adds some structure around it, basing itself on the [SUIT CSS naming conventions](https://github.com/suitcss/suit/blob/master/doc/naming-conventions.md).

This PR also ports anything which was using `classSet`, other than `Todo-item`, to `SuitClassSet`.