### PR TITLE
Fix singleLine mode hotkey handling

### DIFF
--- a/packages/cancelable-edit/index.jsx
+++ b/packages/cancelable-edit/index.jsx
@@ -155,11 +155,16 @@ module.exports = React.createClass({
   },
 
   getHotKeys() {
-    return this.props.singleLine ? _.extend({}, hotKeys, {
+    const hk = hotKeys.slice();
+
+    if (this.props.singleLine) {
+      hk.push({
         mask: {key: 'Enter', metaKey: false, altKey: false},
         cb: 'handleSaveSingleLine',
-      }) :
-      hotKeys;
+      });
+    }
+    
+    return hk;
   },
 
   renderContent(parentClassName) {


### PR DESCRIPTION
Fixes a bug where I try to merge an object into an array, and only half the hotkeys work...