### PR TITLE
visual tweaks to cancelable-edit

### DIFF
--- a/packages/cancelable-edit/index.jsx
+++ b/packages/cancelable-edit/index.jsx
@@ -187,7 +187,7 @@ module.exports = React.createClass({
 
     if (this.props.creating && !this.state.editing) {
       return (
-        <Link onClick={this.handleClick}>
+        <Link fill={this.props.fill} onClick={this.handleClick}>
           {this.props.createText || this.props.placeholder}
         </Link>
       );
@@ -202,7 +202,7 @@ module.exports = React.createClass({
         <Control
           ref="input"
           key="input"
-          rows={!this.singleLine || (this.props.inline ? 1 : 0)}
+          rows={((this.props.em || this.singleLine) ? 1 : 3)}
           onKeyDown={this.keyHandler(this.getHotKeys())}
           className={editClassName}
           value={value}

--- a/packages/cancelable-edit/style.scss
+++ b/packages/cancelable-edit/style.scss
@@ -10,7 +10,7 @@ $color-cancelable-edit-background: darken($color-white, 1) !default;
 $color-cancelable-edit-hover-background: #ffe !default;
 
 input.CancelableEdit-edit.is-editing {
-  margin-bottom: 2px; // to match textareas
+  margin-bottom: 6px; // to match textareas
 }
 
 .CancelableEdit-edit {
@@ -49,7 +49,6 @@ input.CancelableEdit-edit.is-editing {
 .CancelableEdit-edit--em {
   font-size: 28px;
   font-weight: $cancelable-edit-font-weight;
-  line-height: 1.5em;
   letter-spacing: -0.05em;
 }
 


### PR DESCRIPTION

![screen shot 2015-03-02 at 3 38 11 pm](https://cloud.githubusercontent.com/assets/33324/6435435/128fe94e-c0f2-11e4-99dd-18ce9b10837a.png)
margin bottom was too small, line-height looked odd, em was 2 rows by default