### PR TITLE
Make single-line auto-size text area size correctly

### DIFF
--- a/packages/cancelable-edit/example.jsx
+++ b/packages/cancelable-edit/example.jsx
@@ -21,37 +21,69 @@ module.exports = React.createClass({
   render() {
     return (
       <div>
-        <pre> {/*lol es6 literals are too literal */}
-{`<CancelableEdit
-    value={this.state.name}
-    onSave={this.handleNameSave}
-    autoSize
-    placeholder="Name"
-  />`}
-        </pre>
+        <h3>Automatic Sizing</h3>
         <CancelableEdit
           value={this.state.name}
           onSave={this.handleNameSave}
           autoSize
           placeholder="Name"
         />
+        <pre>
+{`<CancelableEdit
+  value={this.state.name}
+  onSave={this.handleNameSave}
+  autoSize
+  placeholder="Name"
+/>`}
+        </pre>
 
-        <br/>
+        <h3>Create mode</h3>
+        <CancelableEdit
+          creating
+          saveButtonText="Create"
+          placeholder="Yo..."
+        />
+        <pre>
+{`<CancelableEdit
+  creating
+  saveButtonText="Create"
+  placeholder="Yo..."
+/>`}
+        </pre>
 
-      <pre>
-{`
-  <CancelableEdit
-    creating
-    saveButtonText="Create"
-    placeholder="Yo..."
-  />
-`}
-      </pre>
-      <CancelableEdit
-        creating
-        saveButtonText="Create"
-        placeholder="Yo..."
-      />
+        <h3>Single-Line Mode</h3>
+        <CancelableEdit
+          value={this.state.name}
+          onSave={this.handleNameSave}
+          singleLine
+          placeholder="Name"
+        />
+        <pre>
+{`<CancelableEdit
+  value={this.state.name}
+  onSave={this.handleNameSave}
+  singleLine
+  placeholder="Name"
+/>`}
+        </pre>
+
+        <h3>Single-Line Mode with Automatic Sizing</h3>
+        <CancelableEdit
+          value={this.state.name}
+          onSave={this.handleNameSave}
+          autoSize
+          singleLine
+          placeholder="Name"
+        />
+        <pre>
+{`<CancelableEdit
+  value={this.state.name}
+  onSave={this.handleNameSave}
+  autoSize
+  singleLine
+  placeholder="Name"
+/>`}
+        </pre>
       </div>
     );
   }

--- a/packages/cancelable-edit/index.jsx
+++ b/packages/cancelable-edit/index.jsx
@@ -84,7 +84,7 @@ module.exports = React.createClass({
 
   handleChange(e) {
     this.setState({
-      pendingValue: e.target.value,
+      pendingValue: this.props.singleLine ? e.target.value.replace(/\r?\n/g, ' ') : e.target.value,
     });
   },
 
@@ -209,7 +209,7 @@ module.exports = React.createClass({
           ref="input"
           key="input"
           maxLength={this.props.maxLength}
-          rows={((this.props.em || this.singleLine) ? 1 : this.props.rows)}
+          rows={((this.props.em || this.props.singleLine) ? 1 : this.props.rows)}
           onKeyDown={this.keyHandler(this.getHotKeys())}
           className={editClassName}
           value={value}

--- a/packages/cancelable-edit/style.scss
+++ b/packages/cancelable-edit/style.scss
@@ -42,6 +42,11 @@ input.CancelableEdit-edit.is-editing {
   }
 }
 
+textarea.CancelableEdit-edit {
+  // Extra padding because 
+  padding: 6px 10px 7px 10px;
+}
+
 .CancelableEdit--inline {
   float: left;
 }

--- a/packages/todo/index.jsx
+++ b/packages/todo/index.jsx
@@ -55,6 +55,7 @@ module.exports = React.createClass({
             ref="input"
             small
             singleLine
+            autoSize
             creating
             saveButtonText="Create Todo"
             saveButtonTitle="Create Todo"

--- a/packages/todo/todo-item.jsx
+++ b/packages/todo/todo-item.jsx
@@ -76,7 +76,6 @@ module.exports = React.createClass({
           className={className.toString()}
           singleLine
           autoSize
-          rows={1}
           small
           inline
           saveButtonText="Save Todo"


### PR DESCRIPTION
part of a fix for macropodhq/stack-client#652
if `singleLine` and `autoSize` are both `true`, the input will start at 1 line, and allow but expand to fit word-wrappedcontent.