### PR TITLE
Covert header

### DIFF
--- a/app/index.jsx
+++ b/app/index.jsx
@@ -70,17 +70,23 @@ function wrapPackage(component) {
 const App = React.createClass({
   displayName: 'App',
 
+  mixins: [Router.State],
+
   render() {
-    return (
-      <div>
-        <h1>Macropod Components</h1>
-        <ul className="PlaygroundTOC">
-          <li><Link to="/">All</Link></li>
-          {packages.map(component => <li key={component.path}><Link to={`/${component.name}`}>{component.friendlyName}</Link></li>)}
-        </ul>
-        <RouteHandler />
-      </div>
-    );
+    if (this.getQuery().iframe) {
+      return <RouteHandler />;
+    } else {
+      return (
+        <div>
+          <h1>Macropod Components</h1>
+          <ul className="PlaygroundTOC">
+            <li><Link to="/">All</Link></li>
+            {packages.map(component => <li key={component.path}><Link to={`/${component.name}`}>{component.friendlyName}</Link></li>)}
+          </ul>
+          <RouteHandler />
+        </div>
+      );
+    }
   }
 });
 
@@ -105,6 +111,7 @@ Router.run(
         render() {return wrapPackage(component);}
       })}/>
     )}
+    <Route name="covert-header-content" path="/covert-header-content" handler={require('../packages/covert-header/content')} />
   </Route>,
   Handler => {
     React.render(

--- a/packages/covert-header/content.jsx
+++ b/packages/covert-header/content.jsx
@@ -1,0 +1,38 @@
+'use strict';
+
+const React = require('react');
+
+const CovertHeader = require('./');
+
+const style = {
+  div: {
+    paddingTop: 40,
+  },
+
+  header: {
+    backgroundColor: 'gray',
+    color: 'white',
+    padding: 10,
+  },
+};
+
+module.exports = React.createClass({
+  displayName: 'CovertHeaderExample',
+
+  componentDidMount() {
+    require('./iframe.scss');
+  },
+
+  render() {
+    return (
+      <div style={style.div}>
+        <CovertHeader style={style.header} offset={40}>
+          Scroll up, scroll down.
+        </CovertHeader>
+
+        <p>Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo. Quisque sit amet est et sapien ullamcorper pharetra. Vestibulum erat wisi, condimentum sed, commodo vitae, ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt condimentum, eros ipsum rutrum orci, sagittis tempus lacus enim ac dui. Donec non enim in turpis pulvinar facilisis. Ut felis. Praesent dapibus, neque id cursus faucibus, tortor neque egestas augue, eu vulputate magna eros eu erat. Aliquam erat volutpat. Nam dui mi, tincidunt quis, accumsan porttitor, facilisis luctus, metus</p>
+        <p>Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo. Quisque sit amet est et sapien ullamcorper pharetra. Vestibulum erat wisi, condimentum sed, commodo vitae, ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt condimentum, eros ipsum rutrum orci, sagittis tempus lacus enim ac dui. Donec non enim in turpis pulvinar facilisis. Ut felis. Praesent dapibus, neque id cursus faucibus, tortor neque egestas augue, eu vulputate magna eros eu erat. Aliquam erat volutpat. Nam dui mi, tincidunt quis, accumsan porttitor, facilisis luctus, metus</p>
+      </div>
+    );
+  }
+});

--- a/packages/covert-header/covert-header.scss
+++ b/packages/covert-header/covert-header.scss
@@ -3,9 +3,6 @@
   top: 0;
   left: 0;
   width: 100%;
-  background-color: gray;
-  color: white;
-  padding: 30px;
   transition: all 0.2s;
 
   &.CovertHeader--hide {

--- a/packages/covert-header/example.jsx
+++ b/packages/covert-header/example.jsx
@@ -2,31 +2,23 @@
 
 const React = require('react');
 
-const CovertHeader = require('./');
-const Button = require('../button');
+const style = {
+  iframe: {
+    width: '100%',
+    height: 150,
+  },
+};
 
 module.exports = React.createClass({
-  displayName: 'CovertHeaderExample',
+  displayName: 'CovertHeaderIframe',
 
-  getInitialState() {
-    return {
-      show: false
-    };
-  },
-
-  toggleHeader() {
-    this.setState({show: !this.state.show});
+  statics: {
+    wide: true,
   },
 
   render() {
     return (
-      <div>
-        <Button onClick={this.toggleHeader}>{this.state.show ? 'Hide' : 'Show'}</Button>
-
-        <CovertHeader style={{'display': this.state.show ? 'block' : 'none'}}>
-          Scroll up, scroll down.
-        </CovertHeader>
-      </div>
+      <iframe src="/#/covert-header-content?iframe=true" frameBorder={0} style={style.iframe} />
     );
   }
 });

--- a/packages/covert-header/iframe.scss
+++ b/packages/covert-header/iframe.scss
@@ -1,0 +1,4 @@
+body {
+  padding: 0;
+  margin: 0;
+}

--- a/packages/covert-header/index.jsx
+++ b/packages/covert-header/index.jsx
@@ -21,14 +21,28 @@
 
 const React = require('react/addons');
 
-require('./covert-header.scss');
+
 const ScrollEvent = require('../scroll-event-mixin');
 const SuitClassSet = require('../suit-class-set');
+
+require('./covert-header.scss');
 
 module.exports = React.createClass({
   displayName: 'CovertHeader',
 
   mixins: [ScrollEvent()],
+
+  propTypes: {
+    offset: React.PropTypes.number,
+    forceShow: React.PropTypes.bool,
+  },
+
+  getDefaultProps() {
+    return {
+      offset: 0,
+      forceShow: false,
+    }
+  },
 
   getInitialState() {
     return {
@@ -37,11 +51,16 @@ module.exports = React.createClass({
   },
 
   onScrollDown() {
-    this.setState({hide: true});
+    const pastOffset = this.props.offset < this.position;
+    if (pastOffset && !this.state.hide && !this.props.forceShow) {
+      this.setState({hide: true});
+    }
   },
 
   onScrollUp() {
-    this.setState({hide: false});
+    if (this.state.hide) {
+      this.setState({hide: false});
+    }
   },
 
   render() {
@@ -52,9 +71,9 @@ module.exports = React.createClass({
     });
 
     return (
-      <header {...this.props} className={covertHeaderClass.toString()} ref="header">
+      <div {...this.props} className={covertHeaderClass.toString()} ref="header">
         {this.props.children}
-      </header>
+      </div>
     );
   }
 });


### PR DESCRIPTION
The main wins here:

- No longer a `header` (as `Bar` is more `header`-esque)
- Takes an `offset`
- Is inside an `iframe`
- `iframe` doesn't include the macropod-components list

Shit:

- The iframe has a scroll jump bug (when the contents is updated?), rest assured, this doesn't happen in a non-iframe environment.
- No documentation. Sue me. Will document when component is actually legit and doesn't rely on a mixin anymore.