### PR TITLE
Markdown editor

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "fecha": "^0.2.1",
     "keymaster": "^1.6.2",
     "lodash-node": "^2.4.1",
+    "marked": "^0.3.3",
     "normalize.css": "~3.0.2",
     "open-sans": "git://github.com/bungeshea/open-sans.git",
     "react": "^0.12.2",

--- a/packages/cancelable-edit/style.scss
+++ b/packages/cancelable-edit/style.scss
@@ -9,12 +9,8 @@ $color-cancelable-edit-focus-border: $color-gull-gray !default;
 $color-cancelable-edit-background: darken($color-white, 1) !default;
 $color-cancelable-edit-hover-background: #ffe !default;
 
-input.CancelableEdit-edit.is-editing {
-  margin-bottom: 6px; // to match textareas
-}
-
-.CancelableEdit-edit {
-  line-height: 1.3em;
+@mixin CancelableEdit-edit() {
+  line-height: 1.3;
   color: $color-cancelable-edit;
   font-weight: $cancelable-edit-font-weight;
   background-color: transparent;
@@ -24,6 +20,14 @@ input.CancelableEdit-edit.is-editing {
   width: 100%;
   border-radius: 3px;
   padding: 5px 10px;
+}
+
+input.CancelableEdit-edit.is-editing {
+  margin-bottom: 6px; // to match textareas
+}
+
+.CancelableEdit-edit {
+  @include CancelableEdit-edit();
   cursor: text;
 
   &:focus {

--- a/packages/markdown-edit/example.jsx
+++ b/packages/markdown-edit/example.jsx
@@ -1,0 +1,144 @@
+const React = require('react');
+
+const CancelableEdit = require('./');
+
+
+module.exports = React.createClass({
+  displayName: 'CancelableEditExample',
+
+  getInitialState() {
+    return {
+      name: `Markdown Sample
+================
+
+## Paragraphs, Headers, Blockquotes
+
+Now is the time for all good men to come to
+the aid of their country. This is just a
+regular paragraph.
+
+The quick brown fox jumped over the lazy
+dog's back.
+
+> This is a blockquote.
+> 
+> This is the second paragraph in the blockquote.
+>
+> ## This is an H2 in a blockquote
+
+### Phrase Emphasis
+
+Some of these words *are emphasized*.
+Some of these words _are emphasized also_.
+
+Use two asterisks for **strong emphasis**.
+Or, if you prefer, __use two underscores instead__.
+
+## Lists
+
+* Candy.
+* Gum.
+* Booze.
+
+
++ Candy.
++ Gum.
++ Booze.
+
+
+- Candy.
+- Gum.
+- Booze.
+
+
+1. Red
+2. Green
+3. Blue
+
+
+* A list item.
+
+  With multiple paragraphs.
+
+* Another item in the list.
+
+### Links
+
+This is an [example link](http://example.com/).
+
+This is an [example link](http://example.com/ "With a Title").
+
+I get 10 times more traffic from [Google][1] than from
+[Yahoo][2] or [MSN][3].
+
+[1]: http://google.com/        "Google"
+[2]: http://search.yahoo.com/  "Yahoo Search"
+[3]: http://search.msn.com/    "MSN Search"
+
+I start my morning with a cup of coffee and
+[The New York Times][NY Times].
+
+[ny times]: http://www.nytimes.com/
+
+### Images
+
+![alt text](/path/to/img.jpg "Title")
+
+### Code
+
+I strongly recommend against using any \`<blink>\` tags.
+
+I wish SmartyPants used named entities like \`&mdash;\`
+instead of decimal-encoded entites like \`&#8212;\`.
+
+If you want your page to validate under XHTML 1.0 Strict,
+you've got to put paragraph tags in your blockquotes:
+
+    <blockquote>
+        <p>For example.</p>
+    </blockquote>`,
+    };
+  },
+
+  handleNameSave(name) {
+    this.setState({
+      name: name,
+    });
+  },
+
+  render() {
+    return (
+      <div>
+        <h3>Automatic Sizing</h3>
+        <CancelableEdit
+          value={this.state.name}
+          onSave={this.handleNameSave}
+          autoSize
+          placeholder="Name"
+        />
+        <pre>
+{`<CancelableEdit
+  value={this.state.name}
+  onSave={this.handleNameSave}
+  autoSize
+  placeholder="Name"
+/>`}
+        </pre>
+
+        <h3>Create mode</h3>
+        <CancelableEdit
+          creating
+          saveButtonText="Create"
+          placeholder="Yo..."
+        />
+        <pre>
+{`<CancelableEdit
+  creating
+  saveButtonText="Create"
+  placeholder="Yo..."
+/>`}
+        </pre>
+      </div>
+    );
+  }
+});

--- a/packages/markdown-edit/index.jsx
+++ b/packages/markdown-edit/index.jsx
@@ -1,6 +1,7 @@
 const React = require('react/addons');
 const AutoSizeTextArea = require('react-textarea-autosize');
 const _ = require('lodash-node');
+const marked = require('marked');
 
 const Alert = require('../alert');
 const Button = require('../button');
@@ -38,7 +39,7 @@ const hotKeys = [
 ];
 
 module.exports = React.createClass({
-  displayName: 'CancelableEdit',
+  displayName: 'MarkdownEdit',
 
   mixins: [KeyMixin],
   propTypes: {
@@ -53,7 +54,6 @@ module.exports = React.createClass({
     createText: React.PropTypes.string,
     small: React.PropTypes.bool,
     inline: React.PropTypes.bool,
-    em: React.PropTypes.bool,
     allowEmpty: React.PropTypes.bool,
     maxLength: React.PropTypes.number,
     autoSize: React.PropTypes.bool,
@@ -66,6 +66,7 @@ module.exports = React.createClass({
   getInitialState() {
     return {
       editing: false,
+      previewing: false,
       pendingValue: '',
       showAlert: false,
     };
@@ -79,10 +80,13 @@ module.exports = React.createClass({
       saveButtonTitleInvalid: 'Save',
       cancelButtonText: 'Cancel',
       cancelButtonTitle: 'Cancel',
+      editButtonText: 'Edit',
+      editButtonTitle: 'Edit',
+      previewButtonText: 'Preview',
+      previewButtonTitle: 'Preview',
       warnMessage: 'Are you sure you want to discard your changes?',
       small: false,
       inline: false,
-      em: false,
       allowEmpty: false,
       autoSize: false,
       creating: false,
@@ -92,41 +96,49 @@ module.exports = React.createClass({
     };
   },
 
+  componentWillMount() {
+    this.markedRenderer = new marked.Renderer();
+    const linkRenderer = this.markedRenderer.link;
+    this.markedRenderer.link = (href, title, text) => linkRenderer.call(this.markedRenderer, href, title, text).replace(/<a /, '<a target="_blank" ');
+  },
+
   handleChange(e) {
     this.setState({
-      pendingValue: this.props.singleLine ? e.target.value.replace(/\r?\n/g, ' ') : e.target.value,
+      pendingValue: e.target.value,
     });
   },
 
   handleConfirmCancel() {
     this.setState({
       showAlert: false,
-    }, () => this.refs.input.getDOMNode().focus());
+    }, () => {
+      if (typeof this.refs.input !== 'undefined') {
+        this.refs.input.getDOMNode().focus();
+      }
+    });
   },
 
   handleConfirmOk() {
     this.setState({
       editing: false,
+      previewing: false,
       showAlert: false,
     }, () => this.props.onCancel());
   },
 
   handleCancel() {
     if (this.unsaved()) {
-      this.refs.input.getDOMNode().blur();
+      if (typeof this.refs.input !== 'undefined') {
+        this.refs.input.getDOMNode().blur();
+      }
       this.setState({
         showAlert: true,
       });
     } else {
       this.setState({
         editing: false,
+        previewing: false,
       }, () => this.props.onCancel());
-    }
-  },
-
-  handleSaveSingleLine() {
-    if (this.props.singleLine) {
-      this.handleSave();
     }
   },
 
@@ -137,6 +149,7 @@ module.exports = React.createClass({
       this.props.onSave(saveValue);
       this.setState({
         editing: false,
+        previewing: false,
         pendingValue: '',
       });
     }
@@ -153,22 +166,32 @@ module.exports = React.createClass({
       (this.state.pendingValue !== ''));
   },
 
-  handleFocus() {
+  handleClick(evt) {
+    evt.preventDefault();
     if (this.isMounted()) {
       if (!this.state.editing) {
         this.setState({
           editing: true,
+          previewing: false,
           pendingValue: this.props.value,
-        }, () => this.refs.input.getDOMNode().focus());
+        }, () => {
+          if (typeof this.refs.input !== 'undefined') {
+            this.refs.input.getDOMNode().focus();
+          }
+        });
       } else {
-        this.refs.input.getDOMNode().focus();
+        if (typeof this.refs.input !== 'undefined') {
+          this.refs.input.getDOMNode().focus();
+        }
       }
     }
   },
 
-  handleClick(evt) {
-    evt.preventDefault();
-    this.handleFocus();
+  handlePreview() {
+    console.log('handlePreview');
+    this.setState({
+      previewing: !this.state.previewing,
+    });
   },
 
   handleBlur() {
@@ -181,25 +204,9 @@ module.exports = React.createClass({
     }, 0);
   },
 
-  getHotKeys() {
-    const hk = hotKeys.slice();
-
-    if (this.props.singleLine) {
-      hk.push({
-        mask: {key: 'Enter', metaKey: false, altKey: false},
-        cb: 'handleSaveSingleLine',
-      });
-    }
-
-    return hk;
-  },
-
   renderContent(parentClassName) {
     const editClassName = parentClassName.createDescendent('edit');
-
-    editClassName.addModifier({
-      'em': this.props.em,
-    });
+    const markdownClassName = parentClassName.createDescendent('markdown');
 
     editClassName.addState({
       'editing': this.state.editing,
@@ -207,12 +214,19 @@ module.exports = React.createClass({
 
     if (this.props.creating && !this.state.editing) {
       return (
-        <Link ref="link" tabIndex="0" href="#" fill={this.props.fill} onClick={this.handleClick}>
+        <Link tabIndex="0" href="#" fill={this.props.fill} onClick={this.handleClick}>
           {this.props.createText || this.props.placeholder}
         </Link>
       );
+    } else if (this.state.previewing || !this.state.editing) {
+      const value = this.state.editing ? this.state.pendingValue : this.props.value;
+
+      return [
+        <label key="label" style={{'display': 'none'}}>{this.props.name}</label>,
+        <div className={markdownClassName} dangerouslySetInnerHTML={{__html: marked(value, {renderer: this.markedRenderer,})}} />,
+      ];
     } else {
-      const Control = this.props.autoSize ? AutoSizeTextArea : (this.props.singleLine ? 'input' : 'textarea');
+      const Control = this.props.autoSize ? AutoSizeTextArea : 'textarea';
       const value = this.state.editing ? this.state.pendingValue : this.props.value;
 
       return [
@@ -221,21 +235,22 @@ module.exports = React.createClass({
           ref="input"
           key="input"
           maxLength={this.props.maxLength}
-          rows={((this.props.em || this.props.singleLine) ? 1 : this.props.rows)}
-          onKeyDown={this.keyHandler(this.getHotKeys())}
+          rows={this.props.rows}
+          onKeyDown={this.keyHandler(hotKeys)}
           className={editClassName}
           value={value}
-          onFocus={this.handleFocus}
           onChange={this.handleChange}
           name={this.props.name}
+          readOnly={!this.state.editing}
           placeholder={this.props.placeholder}
+          onBlur={this.handleBlur}
         />,
       ];
     }
   },
 
   render() {
-    const className = new SuitClassSet('CancelableEdit');
+    const className = new SuitClassSet('MarkdownEdit');
 
     className.addState({
       'active': this.state.editing,
@@ -247,6 +262,17 @@ module.exports = React.createClass({
 
     return (
       <div className={className.toString() + (this.props.className ? ` ${this.props.className}` : '')} onBlur={this.handleBlur}>
+        { !this.props.creating && !this.state.editing && 
+            <Button
+                style={{'float': 'right'}}
+                title={this.props.editButtonTitle}
+                small={this.props.small}
+                success
+                onClick={this.handleClick}
+              >
+              {this.props.editButtonText}
+            </Button>
+        }
         { this.renderContent(className) }
         { this.state.editing &&
           <div className="CancelableEdit-control">
@@ -266,6 +292,14 @@ module.exports = React.createClass({
                 onClick={this.handleCancel}
               >
               {this.props.cancelButtonText}
+            </Button>
+            <Button
+                title={this.props.previewButtonTitle}
+                small={this.props.small}
+                skeleton
+                onClick={this.handlePreview}
+              >
+              {this.props.previewButtonText}
             </Button>
             { this.state.showAlert &&
               <Alert

--- a/packages/markdown-edit/index.jsx
+++ b/packages/markdown-edit/index.jsx
@@ -56,7 +56,6 @@ module.exports = React.createClass({
     inline: React.PropTypes.bool,
     allowEmpty: React.PropTypes.bool,
     maxLength: React.PropTypes.number,
-    autoSize: React.PropTypes.bool,
     creating: React.PropTypes.bool,
     rows: React.PropTypes.number,
     onSave: React.PropTypes.func.isRequired,
@@ -88,7 +87,6 @@ module.exports = React.createClass({
       small: false,
       inline: false,
       allowEmpty: false,
-      autoSize: false,
       creating: false,
       rows: 3,
       onSave: noop,
@@ -226,12 +224,11 @@ module.exports = React.createClass({
         <div className={markdownClassName} dangerouslySetInnerHTML={{__html: marked(value, {renderer: this.markedRenderer,})}} />,
       ];
     } else {
-      const Control = this.props.autoSize ? AutoSizeTextArea : 'textarea';
       const value = this.state.editing ? this.state.pendingValue : this.props.value;
 
       return [
         <label key="label" style={{'display': 'none'}}>{this.props.name}</label>,
-        <Control
+        <AutoSizeTextArea
           ref="input"
           key="input"
           maxLength={this.props.maxLength}

--- a/packages/markdown-edit/index.jsx
+++ b/packages/markdown-edit/index.jsx
@@ -52,6 +52,7 @@ module.exports = React.createClass({
     warnMessage: React.PropTypes.string,
     placeholder: React.PropTypes.string,
     createText: React.PropTypes.string,
+    defaultStyles: React.PropTypes.bool,
     small: React.PropTypes.bool,
     inline: React.PropTypes.bool,
     allowEmpty: React.PropTypes.bool,
@@ -84,6 +85,7 @@ module.exports = React.createClass({
       previewButtonText: 'Preview',
       previewButtonTitle: 'Preview',
       warnMessage: 'Are you sure you want to discard your changes?',
+      defaultStyles: true,
       small: false,
       inline: false,
       allowEmpty: false,
@@ -208,6 +210,10 @@ module.exports = React.createClass({
 
     editClassName.addState({
       'editing': this.state.editing,
+    });
+
+    markdownClassName.addModifier({
+      'defaultStyles': this.props.defaultStyles,
     });
 
     if (this.props.creating && !this.state.editing) {

--- a/packages/markdown-edit/index.jsx
+++ b/packages/markdown-edit/index.jsx
@@ -247,7 +247,7 @@ module.exports = React.createClass({
   },
 
   render() {
-    const className = new SuitClassSet('MarkdownEdit');
+    const className = new SuitClassSet('CancelableEdit');
 
     className.addState({
       'active': this.state.editing,

--- a/packages/markdown-edit/style.scss
+++ b/packages/markdown-edit/style.scss
@@ -9,21 +9,35 @@ $color-cancelable-edit-focus-border: $color-gull-gray !default;
 $color-cancelable-edit-background: darken($color-white, 1) !default;
 $color-cancelable-edit-hover-background: #ffe !default;
 
-input.CancelableEdit-edit.is-editing {
+input.MarkdownEdit-edit.is-editing {
   margin-bottom: 6px; // to match textareas
 }
 
-.CancelableEdit-edit {
-  line-height: 1.3em;
+.MarkdownEdit-edit,
+.MarkdownEdit-markdown {
+  line-height: 1.3;
   color: $color-cancelable-edit;
   font-weight: $cancelable-edit-font-weight;
   background-color: transparent;
   border: 1px solid transparent;
   outline: 0;
-  resize: none;
   width: 100%;
   border-radius: 3px;
   padding: 5px 10px;
+}
+
+.MarkdownEdit-markdown {
+  & > *:first-child {
+    margin-top: 0;
+  }
+
+  & > *:last-child {
+    margin-bottom: 0;
+  }
+}
+
+.MarkdownEdit-edit {
+  resize: none;
   cursor: text;
 
   &:focus {
@@ -42,22 +56,16 @@ input.CancelableEdit-edit.is-editing {
   }
 }
 
-textarea.CancelableEdit-edit {
+textarea.MarkdownEdit-edit {
   // Extra padding because 
   padding: 6px 10px 7px 10px;
 }
 
-.CancelableEdit--inline {
+.MarkdownEdit--inline {
   float: left;
 }
 
-.CancelableEdit-edit--em {
-  font-size: 28px;
-  font-weight: $cancelable-edit-font-weight;
-  letter-spacing: -0.05em;
-}
-
-.CancelableEdit-controls {
+.MarkdownEdit-controls {
   overflow: hidden;
   padding: 0 0 10px;
   border-bottom: 1px solid $color-cancelable-edit-border;

--- a/packages/markdown-edit/style.scss
+++ b/packages/markdown-edit/style.scss
@@ -1,32 +1,9 @@
-@import "colors";
+@import "../cancelable-edit/style";
 
-$cancelable-edit-font-weight: 400 !default;
+.CancelableEdit-markdown {
+  @include CancelableEdit-edit();
+  cursor: default;
 
-$color-cancelable-edit: $color-scorpion !default;
-$color-cancelable-edit-border: $color-catskill-white !default;
-$color-cancelable-edit-hover-border: mix(#111, #ffe, 10) !default;
-$color-cancelable-edit-focus-border: $color-gull-gray !default;
-$color-cancelable-edit-background: darken($color-white, 1) !default;
-$color-cancelable-edit-hover-background: #ffe !default;
-
-input.MarkdownEdit-edit.is-editing {
-  margin-bottom: 6px; // to match textareas
-}
-
-.MarkdownEdit-edit,
-.MarkdownEdit-markdown {
-  line-height: 1.3;
-  color: $color-cancelable-edit;
-  font-weight: $cancelable-edit-font-weight;
-  background-color: transparent;
-  border: 1px solid transparent;
-  outline: 0;
-  width: 100%;
-  border-radius: 3px;
-  padding: 5px 10px;
-}
-
-.MarkdownEdit-markdown {
   & > *:first-child {
     margin-top: 0;
   }
@@ -34,43 +11,4 @@ input.MarkdownEdit-edit.is-editing {
   & > *:last-child {
     margin-bottom: 0;
   }
-}
-
-.MarkdownEdit-edit {
-  resize: none;
-  cursor: text;
-
-  &:focus {
-    border: 1px solid $color-cancelable-edit-focus-border;
-    box-shadow: inset 0 1px 1px rgba(0, 0, 0 ,.075), 0 0 8px #66afe9;
-  }
-
-  &.is-editing {
-    background-color: $color-cancelable-edit-background;
-  }
-
-  &:not(.is-editing):hover {
-    background-color: $color-cancelable-edit-hover-background;
-    border: 1px solid $color-cancelable-edit-hover-border;
-    cursor: pointer;
-  }
-}
-
-textarea.MarkdownEdit-edit {
-  // Extra padding because 
-  padding: 6px 10px 7px 10px;
-}
-
-.MarkdownEdit--inline {
-  float: left;
-}
-
-.MarkdownEdit-controls {
-  overflow: hidden;
-  padding: 0 0 10px;
-  border-bottom: 1px solid $color-cancelable-edit-border;
-  margin: 2px 0 0 0;
-  bottom: 0;
-  width: 100%;
-  text-align: right;
 }

--- a/packages/markdown-edit/style.scss
+++ b/packages/markdown-edit/style.scss
@@ -11,4 +11,36 @@
   & > *:last-child {
     margin-bottom: 0;
   }
+
+  &.CancelableEdit-markdown--defaultStyles {
+    blockquote {
+      margin: 0;
+      padding: 0 15px;
+      color: #777;
+      border-left: 4px solid #ddd;
+    }
+
+    code {
+      padding: 0.2em;
+      margin: 0;
+      font-size: 85%;
+      background-color: rgba(0,0,0,0.04);
+      border-radius: 3px;
+    }
+
+    pre {
+      padding: 16px;
+      overflow: auto;
+      font-size: 85%;
+      line-height: 1.45;
+      background-color: #f7f7f7;
+      border-radius: 3px;
+
+      code {
+        background-color: transparent;
+        font-size: 1em;
+        padding: 0;
+      }
+    }
+  }
 }


### PR DESCRIPTION
Adds a Markdown editor based on the `CancelableEdit` component.

![screen shot 2015-04-23 at 11 09 42 am](https://cloud.githubusercontent.com/assets/282113/7288716/4bce8e9c-e9a9-11e4-964f-5921db621d17.png)

It features previewing, keyboard accessibility and two of the same modes the `CancelableEdit` supports.
This branch also upgrades `CancelableEdit`’s interaction model to match the new one introduced by `MarkdownEdit`, including improved keyboard accessibility support and the ability to tab to buttons inside the control.

Includes a handful of styles scoped directly to the Markdown editor, which can be opted out of by setting the `defaultStyles` prop to `false`. The styles add some defaults to `code`, `pre` and `blockquote` elements. The included styles do not provide any typographic styling.