### PR TITLE
`active` link doesn't look clickable anymore

### DIFF
--- a/packages/link-group/link-group.scss
+++ b/packages/link-group/link-group.scss
@@ -18,11 +18,17 @@
       background: $input-state-focus;
       color: $input-state-focus-text;
       border-right-width: $input-border-width;
+      cursor: default;
+
       &+ .Link {
         border-left-width: 0;
       }
       &:last-child {
        border-right-width: $input-border-width;
+      }
+      &:hover {
+        background: $input-state-focus;
+        opacity: 0.8;
       }
     }
 


### PR DESCRIPTION
you can still click on it, but coaxes the user into thinking this is more of an 'active' state i spose