### PR TITLE
Inherit vertical align from svg `Icon`

### DIFF
--- a/packages/icon/icon.scss
+++ b/packages/icon/icon.scss
@@ -4,6 +4,6 @@
   svg {
     height: 1em;
     fill: currentColor;
+    vertical-align: inherit;
   }
-
 }


### PR DESCRIPTION
This one has no visible changes. Stack's subnav needs the svg to have `vertical-align: middle` but this will affect all icons everywhere. Matt and I had a chat about this, and we'd prefer to style it on the parent.