### PR TITLE
Handle values provided by AutoFill or other means

### DIFF
--- a/packages/form/input-checkbox.jsx
+++ b/packages/form/input-checkbox.jsx
@@ -24,10 +24,16 @@ module.exports = React.createClass({
         inputType="checkbox"
         label={this.props.label}
         showLabel={this.props.showLabel}
-        errorMessage={this.props.errorMessage}>
-        
+        errorMessage={this.props.errorMessage}
+      >
         <label>
-          <input {...this.props} ref="input" type="checkbox" id={`Input--checkbox--${camelCaseLabel}`} className={`Input Input--checkbox Input--checkbox--${camelCaseLabel}`} />
+          <input
+            {...this.props}
+            ref="input"
+            type="checkbox"
+            id={`Input--checkbox--${camelCaseLabel}`}
+            className={`Input Input--checkbox Input--checkbox--${camelCaseLabel}`}
+          />
           {this.props.checkboxLabel}
         </label>
       </InputWrapper>

--- a/packages/form/input-text.jsx
+++ b/packages/form/input-text.jsx
@@ -8,11 +8,79 @@ require('./input-text.scss');
 module.exports = React.createClass({
   displayName: 'InputText',
 
+  propTypes: {
+    label: React.PropTypes.node,
+    type: React.PropTypes.string.isRequired,
+    autoComplete: React.PropTypes.oneOfType([
+      React.PropTypes.string,
+      React.PropTypes.bool,
+    ]),
+  },
+
   getDefaultProps() {
     return {
       label: '',
       type: 'text',
     };
+  },
+
+  autoCompleteOn() {
+    return (''+this.props.autoComplete).toLowerCase() !== 'off';
+  },
+
+  enableUnmanagedChangeHandler() {
+    if (this.autoCompleteOn() && typeof this.handleUnmanagedChange.intervalId === 'undefined') {
+      this.handleUnmanagedChange.intervalId = setInterval(this.handleUnmanagedChange, 100);
+    }
+  },
+
+  disableUnmanagedChangeHandler() {
+    if (typeof this.handleUnmanagedChange.intervalId !== 'undefined') {
+      clearInterval(this.handleUnmanagedChange.intervalId);
+      delete this.handleUnmanagedChange.intervalId;
+    }
+  },
+
+  componentDidMount() {
+    this.enableUnmanagedChangeHandler();
+  },
+
+  componentWillUnmount() {
+    this.disableUnmanagedChangeHandler();
+  },
+
+  componentWillReceiveProps(nextProps) {
+    if (this.autoCompleteOn()) {
+      this.enableUnmanagedChangeHandler();
+    } else {
+      this.disableUnmanagedChangeHandler();
+    }
+  },
+
+  handleUnmanagedChange() {
+    const target = this.refs.input.getDOMNode();
+
+    if (target.value !== this.handleUnmanagedChange.lastValue) {
+      if (typeof this.handleUnmanagedChange.lastValue !== 'undefined' && this.props.onChange instanceof Function) {
+        this.props.onChange({
+          currentTarget: target,
+          target,
+          timeStamp: Date.now(),
+        });
+      }
+
+      this.handleUnmanagedChange.lastValue = target.value;
+    }
+  },
+
+  handleChange(evt) {
+    if (this.props.onChange instanceof Function) {
+      this.props.onChange(evt);
+    }
+
+    if (this.autoCompleteOn()) {
+      this.handleUnmanagedChange.lastValue = evt.target.value;
+    }
   },
 
   focusInput() {
@@ -31,8 +99,16 @@ module.exports = React.createClass({
         inputType={this.props.type}
         label={this.props.label}
         showLabel={this.props.showLabel}
-        errorMessage={this.props.errorMessage}>
-          <input {...this.props} ref="input" type={this.props.type} id={`Input--text--${camelCaseLabel}`} className={`Input Input--text Input--text--${camelCaseLabel}`} />
+        errorMessage={this.props.errorMessage}
+      >
+        <input
+          {...this.props}
+          onChange={this.handleChange}
+          ref="input"
+          type={this.props.type}
+          id={`Input--text--${camelCaseLabel}`}
+          className={`Input Input--text Input--text--${camelCaseLabel}`}
+        />
       </InputWrapper>
     );
   },


### PR DESCRIPTION
This adds a polling-based solution to the issue where React can't see values provided by browser AutoFill features and add-ons.
If the value of the `autoComplete` property on an `InputText` component is not `"off"`, any values provided by means other than normal user input (`onChange`) has additional handling. This catches both automatic and user-initiated form filling.

This has the unfortunate side effect of making `valueLink` unusable as React will complain about using both it and `onChange`, which we need to use in order to elegantly handle managed and non-managed value changes.

part of a solution for macropodhq/pouch-client#75