### PR TITLE
Allow word-wrap in buttons, make them scaleable

### DIFF
--- a/packages/button/button.scss
+++ b/packages/button/button.scss
@@ -25,11 +25,10 @@ $color-button-skeleton: $color-scorpion !default;
 .Button {
   display: inline-block;
   border: 0;
-  border-radius: 3px;
+  border-radius: .3em;
   margin-bottom: 0;
-  padding: 0 1.5em;
-  height: 3em;
-  line-height: 3em;
+  padding: .8em 1.5em;
+  line-height: 1.25em;
   font-size: $button-font-size;
   font-family: $button-font-family;
   font-weight: $button-font-weight;
@@ -37,7 +36,6 @@ $color-button-skeleton: $color-scorpion !default;
   text-shadow: 0 1px 0 rgba(#000, .15);
   color: $color-button-default;
   background-color: $color-button-default-background;
-  white-space: nowrap;
   user-select: none;
 
   &[disabled] {
@@ -89,7 +87,5 @@ $color-button-skeleton: $color-scorpion !default;
 }
 
 .Button--small {
-  padding: 0 1em;
-  height: 2em;
-  line-height: 2em;
+  padding: .45em 1em;
 }

--- a/packages/button/example.jsx
+++ b/packages/button/example.jsx
@@ -21,13 +21,29 @@ module.exports = React.createClass({
   render() {
     return (
       <div className="ButtonExample">
+        <h4>Button Types</h4>
+
         <Button onClick={this.handleClick}>Default</Button><br />
         <Button success onClick={this.handleClick}>Success</Button><br />
         <Button danger onClick={this.handleClick}>Danger</Button><br />
-        <Button disabled onClick={this.handleClick}>Disabled (default)</Button><br />
         <Button cancel onClick={this.handleClick}>Cancel</Button><br />
-        <Button skeleton onClick={this.handleClick}>Skeleton (no border, outline or background)</Button><br />
+        <Button skeleton onClick={this.handleClick}>
+          Skeleton<br />
+          (no border, outline or background)
+        </Button>
+
+        <h4>Modifiers</h4>
+
+        <p>Can be used on any Button type. Here they're used on the Default.</p>
         <Button small onClick={this.handleClick}>Small</Button><br />
+        <Button disabled onClick={this.handleClick}>
+          Disabled<br />
+          (fades out colour of button type)
+        </Button>
+
+        <h4>Novelties</h4>
+
+        <p>This button demonstrates that the Button component gracefully supports any <code>background-color</code></p>
         <Button className="Button--custom" onClick={this.handleClick}>Custom</Button>
         <br/>
         You've clicked {this.state.count} button{this.state.count === 1 ? '' : 's'}


### PR DESCRIPTION
Also organise the example page a little better; we have, more or less, two classes of props - this organises around those