### PR TITLE
Fix refocusing on todo creator

### DIFF
--- a/packages/todo/index.jsx
+++ b/packages/todo/index.jsx
@@ -40,7 +40,9 @@ module.exports = React.createClass({
   },
 
   focusNewInput() {
-    this.refs.input.focus();
+    if (this.isMounted && this.refs.input) {
+      this.refs.input.handleFocus();
+    }
   },
 
   render() {


### PR DESCRIPTION
This was broken by the change to using CancelableEdit instead of a normal text input.
focusNewInput() now actually puts focus on the new input.

