### PR TITLE
Make many components resolution-independent

### DIFF
--- a/packages/icon-button/style.scss
+++ b/packages/icon-button/style.scss
@@ -1,4 +1,5 @@
 @import "colors";
+@import "pixels-to-em";
 
 $icon-button-size: 1.65em;
 
@@ -11,6 +12,7 @@ $color-icon-button-background-hover: $color-fountain-blue !default;
 .IconButton {
   display: inline-block;
   color: $color-icon-button;
+  font-size: inherit;
   background-color: $color-icon-button-background;
   border-radius: ($icon-button-size / 2);
   height: $icon-button-size;
@@ -23,7 +25,7 @@ $color-icon-button-background-hover: $color-fountain-blue !default;
   outline: none;
 
   &:focus {
-    box-shadow: 0 0 0 1px rgba(0,0,0,.1),0 0 6px rgba(0,0,0,.3);
+    box-shadow: 0 0 0 pixelsToEm(1) rgba(0,0,0,.1),0 0 pixelsToEm(6) rgba(0,0,0,.3);
   }
 
   &:focus,

--- a/packages/markdown-edit/style.scss
+++ b/packages/markdown-edit/style.scss
@@ -1,4 +1,5 @@
-@import 'inputs';
+@import "inputs";
+@import "pixels-to-em";
 
 .CancelableEdit-markdown {
   padding: $input-padding;
@@ -17,14 +18,12 @@
     pointer-events: none;
   }
 
-
-
   &.CancelableEdit-markdown--defaultStyles {
     blockquote {
       margin: 0;
-      padding: 0 15px;
+      padding: 0 pixelsToEm(15);
       color: #777;
-      border-left: 4px solid #ddd;
+      border-left: pixelsToEm(4) solid #ddd;
     }
 
     code {
@@ -32,7 +31,7 @@
       margin: 0;
       font-size: 85%;
       background-color: rgba(0,0,0,0.04);
-      border-radius: 3px;
+      border-radius: pixelsToEm(3);
     }
 
     img {
@@ -40,12 +39,12 @@
     }
 
     pre {
-      padding: 16px;
+      padding: pixelsToEm(16);
       overflow: auto;
       font-size: 85%;
       line-height: 1.45;
       background-color: #f7f7f7;
-      border-radius: 3px;
+      border-radius: pixelsToEm(3);
 
       code {
         background-color: transparent;

--- a/packages/modal/index.jsx
+++ b/packages/modal/index.jsx
@@ -81,6 +81,7 @@ module.exports = React.createClass({
     modalClasses.addModifier({
       'visible': this.state.showModal,
       'invisible': !this.state.showModal,
+      'forceMobile': this.props.forceMobile === true,
     });
 
     const dialogClasses = modalClasses.createDescendent('dialog');

--- a/packages/modal/modal.scss
+++ b/packages/modal/modal.scss
@@ -1,11 +1,12 @@
 @import "colors";
+@import "pixels-to-em";
 
-$modal-max-width: 1280px;
-$modal-main-breakpoint: 600px;
-$modal-padding: 15px;
+$modal-max-width: pixelsToEm(1280);
+$modal-main-breakpoint: pixelsToEm(600);
+$modal-padding: pixelsToEm(15);
 
-$modal-header-height: 45px;
-$modal-footer-height: 55px;
+$modal-header-height: pixelsToEm(45);
+$modal-footer-height: pixelsToEm(55);
 
 $color-dialog-background: $color-white;
 $color-modal-box-shadow: rgba($color-black, 0.5);
@@ -34,42 +35,51 @@ $transition-easing: cubic-bezier(1.000, 0.000, 0.000, 1.000);
   transition: all $transition-length $transition-easing;
   height: 100%;
   box-sizing: border-box;
-  padding: 30px;
+  padding: pixelsToEm(30);
+
   * {
     box-sizing: border-box;
   }
+
   &.Modal--visible {
     opacity: 1;
     transition: all $transition-length $transition-easing;
   }
 
+  &.Modal--forceMobile {
+    padding: pixelsToEm(5);
+  }
+
   @media (max-width: $modal-main-breakpoint) {
-    padding: 5px;
+    padding: pixelsToEm(5);
   }
 }
 
 .Modal-dialog {
   position: relative;
   transition: all $transition-length $transition-easing;
-  box-shadow: 0 3px 9px $color-modal-box-shadow;
+  box-shadow: 0 pixelsToEm(3) pixelsToEm(9) $color-modal-box-shadow;
   background: $color-dialog-background;
-  border-radius: 2px;
+  border-radius: pixelsToEm(2);
   overflow: hidden;
   width: 100%;
   margin: 0 auto;
   height: 100%;
+
   &.Modal-dialog--withHeader {
     .Modal-content {
       padding-top: 0;
       height: calc(100% - #{$modal-header-height});
     }
   }
+
   &.Modal-dialog--withFooter {
     .Modal-content {
       padding-bottom: 0;
       height: calc(100% - #{$modal-footer-height});
     }
-  }  
+  }
+
   &.Modal-dialog--withHeader.Modal-dialog--withFooter {
     .Modal-content {
       height: calc(100% - #{$modal-header-height + $modal-footer-height});
@@ -86,42 +96,53 @@ $transition-easing: cubic-bezier(1.000, 0.000, 0.000, 1.000);
 
   // TODO: this should not be
   &.Modal-dialog--newTask {
-    max-width: 850px;
+    max-width: pixelsToEm(850);
 
     .Task-attributes *, .Task-attributes *:hover {
       cursor: default !important;
     }
   }
 
-  @media (max-width: $modal-main-breakpoint) {
-    border-radius: 2px;
+  .Modal--forceMobile & {
+    border-radius: pixelsToEm(2);
     height: 100%;
     width: 100%;
     max-width: 100% !important;
-    min-height: 1px;
+    min-height: pixelsToEm(1);
+    border: 0;
+  }
+
+  @media (max-width: $modal-main-breakpoint) {
+    border-radius: pixelsToEm(2);
+    height: 100%;
+    width: 100%;
+    max-width: 100% !important;
+    min-height: pixelsToEm(1);
     border: 0;
   }
 }
 
 .Modal-header {
-  padding: 10px 20px;
+  padding: pixelsToEm(10) pixelsToEm(20);
   height: $modal-header-height;
-  line-height: $modal-header-height - 20px;
+  line-height: $modal-header-height - pixelsToEm(20);
+
   h2 {
     display: inlline-block;
     margin: 0;
     font-weight: 400;
-    font-size: 18px;
+    font-size: pixelsToEm(18);
   }
 }
 
 .Modal-close {
   position: absolute;
-  top: 10px;
-  right: 10px;
+  top: pixelsToEm(10);
+  right: pixelsToEm(10);
   text-decoration: none;
   color: $color-modal-close;
-  line-height: $modal-header-height - 20px;
+  line-height: $modal-header-height - pixelsToEm(20);
+
   &:hover {
     color: $color-modal-close-hover;
   }
@@ -129,11 +150,11 @@ $transition-easing: cubic-bezier(1.000, 0.000, 0.000, 1.000);
 
 .Modal-content {
   overflow: auto;
-  padding: 10px 20px;
+  padding: pixelsToEm(10) pixelsToEm(20);
 }
 
 .Modal-footer {
-  padding: 10px 20px 20px;
+  padding: pixelsToEm(10) pixelsToEm(20) pixelsToEm(20);
   text-align: right;
   height: $modal-footer-height;
 }

--- a/packages/prompt/index.jsx
+++ b/packages/prompt/index.jsx
@@ -60,14 +60,14 @@ module.exports = React.createClass({
     }
   },
 
-  handleCancel() {
+  handleCancel(evt) {
+    evt.preventDefault();
     this.props.onCancel(this.state.value);
-    return false;
   },
 
-  handleOk() {
+  handleOk(evt) {
+    evt.preventDefault();
     this.props.onOk(this.state.value);
-    return false;
   },
 
   handleValueChange(event) {

--- a/style/inputs.scss
+++ b/style/inputs.scss
@@ -1,16 +1,17 @@
 @import "colors";
+@import "pixels-to-em";
 
 $input-base-color: #243b5d;
 $input-background-color: #fdfdff;
 $input-border-color: rgba($input-base-color, .25);
-$input-border-radius: 3px;
-$input-border-width: 1px;
+$input-border-radius: pixelsToEm(3);
+$input-border-width: pixelsToEm(1);
 
 $input-text-color: inherit;
 $input-placeholder-color: inherit;
 
-$input-height: 38px;
-$input-padding: 8px 10px;
+$input-height: pixelsToEm(38);
+$input-padding: pixelsToEm(8) pixelsToEm(10);
 $input-line-height: 1.3;
 
 $input-state-hover: rgba($input-base-color, .10);
@@ -34,10 +35,14 @@ $input-state-error: #d46060;
   outline: none;
   box-sizing: border-box;
   transition: all .1s;
+  font-family: inherit;
+  font-size: inherit;
+
   &::placeholder {
     color: $input-placeholder-color;
     opacity: .4;
   }
+
   &:focus {
     border-color: $input-state-focus;
 

--- a/style/pixels-to-em.scss
+++ b/style/pixels-to-em.scss
@@ -1,0 +1,3 @@
+@function pixelsToEm($pixels, $fontSize: 16){
+  @return ($pixels / $fontSize) * 1em;
+}


### PR DESCRIPTION
- implements a `pixelsToEm` Sass function, which converts pixel values to `em` based on our default font size of 16px
- uses said function to change all measurements in affected components to `em`s so they can be scaled to any size
- improves inheritance of font sizes in some cases
- adds a `forceMobile` property to the `Modal`, which allows you to force the mobile viewport style
  - this was added to work around the fact that in Bugherd's scaling model, the media queries don't scale with the page. More work might allow us to fix this in CSS, but at this point the JS solution seems best