### PR TITLE
Normalise event handlers

### DIFF
--- a/packages/alert/index.jsx
+++ b/packages/alert/index.jsx
@@ -42,14 +42,14 @@ module.exports = React.createClass({
     };
   },
 
-  handleCancel() {
+  handleCancel(evt) {
+    evt.preventDefault();
     this.props.onCancel();
-    return false;
   },
 
-  handleOk() {
+  handleOk(evt) {
+    evt.preventDefault();
     this.props.onOk();
-    return false;
   },
 
   componentDidMount() {

--- a/packages/comments/comment.jsx
+++ b/packages/comments/comment.jsx
@@ -132,14 +132,14 @@ module.exports = React.createClass({
   },
 
   handleKeyDown(callback, e) {
-    if (!e) {
-      e = window.event; // TODO: is this ever so? makes this harder to test
+    if (!evt) {
+      evt = window.event; // TODO: is this ever so? makes this harder to test
     }
 
-    const keyCode = e.keyCode || e.which;
-    if (keyCode === 13 && !e.ctrlKey && !e.shiftKey){
+    const keyCode = evt.keyCode || evt.which;
+    if (keyCode === 13 && !evt.ctrlKey && !evt.shiftKey){
       callback();
-      return false;
+      evt.preventDefault();
     }
   },
 

--- a/packages/comments/comment.jsx
+++ b/packages/comments/comment.jsx
@@ -131,13 +131,13 @@ module.exports = React.createClass({
     this.handleEditToggle();
   },
 
-  handleKeyDown(callback, e) {
+  handleKeyDown(callback, evt) {
     if (!evt) {
       evt = window.event; // TODO: is this ever so? makes this harder to test
     }
 
     const keyCode = evt.keyCode || evt.which;
-    if (keyCode === 13 && !evt.ctrlKey && !evt.shiftKey){
+    if (keyCode === 13 && !evt.ctrlKey && !evt.shiftKey) {
       callback();
       evt.preventDefault();
     }

--- a/packages/comments/example.jsx
+++ b/packages/comments/example.jsx
@@ -147,16 +147,15 @@ module.exports = React.createClass({
     this.setState({comments: updatedComments});
   },
 
-  handleKeyDown(callback, e) {
-    if (!e) {
-      e = window.event;
+  handleKeyDown(callback, evt) {
+    if (!evt) {
+      evt = window.event;
     }
 
-    const keyCode = e.keyCode || e.which;
-
-    if (keyCode === 13 && !e.ctrlKey && !e.shiftKey){
+    const keyCode = evt.keyCode || evt.which;
+    if (keyCode === 13 && !evt.ctrlKey && !evt.shiftKey){
       callback();
-      return false;
+      evt.preventDefault();
     }
   },
 

--- a/packages/guider/index.jsx
+++ b/packages/guider/index.jsx
@@ -29,14 +29,14 @@ module.exports = React.createClass({
     };
   },
 
-  handleClose() {
+  handleClose(evt) {
+    evt.preventDefault();
     this.props.onClose();
-    return false;
   },
 
-  handleNext() {
+  handleNext(evt) {
+    evt.preventDefault();
     this.props.onNext();
-    return false;
   },
 
   render() {

--- a/packages/key-mixin/index.jsx
+++ b/packages/key-mixin/index.jsx
@@ -1,22 +1,22 @@
 const _ = require('lodash-node');
 
 module.exports = {
-  _keyMixinHandleKeyDown(eventMaskCbPairs, e) {
+  _keyMixinHandleKeyDown(eventMaskCbPairs, evt) {
     if (!_.isArray(eventMaskCbPairs)) {
       eventMaskCbPairs = [eventMaskCbPairs];
     }
 
     let callbacks = _.map(eventMaskCbPairs,
       (pair) => _.all(pair.mask,
-        (value, key) => e[key] === value
+        (value, key) => evt[key] === value
       ) && pair.cb
     );
     callbacks = _.compact(callbacks);
 
-    _.each(callbacks, (cb) => this[cb](e));
+    _.each(callbacks, (cb) => this[cb](evt));
 
     if (callbacks.length > 0) {
-      return false;
+      evt.preventDefault();
     }
   },
 

--- a/packages/modal/index.jsx
+++ b/packages/modal/index.jsx
@@ -59,7 +59,8 @@ module.exports = React.createClass({
     });
   },
 
-  handleClose() {
+  handleClose(evt) {
+    evt.preventDefault();
     if (!this.isMounted()) {
       return;
     }
@@ -68,7 +69,6 @@ module.exports = React.createClass({
     });
 
     animationCallback(this._layer.querySelector('.Modal-dialog'), this.props.onClose);
-    return false;
   },
 
   stopPropagation(event) {


### PR DESCRIPTION
use `evt` as the event name, and replace `return false`s with `evt.preventDefault()` calls