### PR TITLE
Adds `MarkdownSnippet`

### DIFF
--- a/packages/markdown-snippet/README.md
+++ b/packages/markdown-snippet/README.md
@@ -1,0 +1,23 @@
+# Markdown Snippet
+
+A small component to display a snippet of markdown in a document.
+
+## Usage
+
+```
+<MarkdownSnippet markdown="# Your markdown goes here" />
+```
+
+## Properties
+
+### `markdown`
+
+The unformatted markdown text to render
+
+### `defaultStyles`
+
+If set to false, doesn't apply the component's Markdown styles and relies on external or browser provided styles
+
+### `linkTarget`
+
+Allows setting the `target` attribute of generated Markdown links. Valid values are `"_self"`, `"_blank"`, `"_parent"` and `"_top"`.

--- a/packages/markdown-snippet/example.jsx
+++ b/packages/markdown-snippet/example.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+
+import MarkdownSnippet from './';
+
+const markdown = `##### Markdown Snippet
+
+> Here's a blockquote!!!
+
+This is a Markdown snippet. You can do _all_ kinds of strange things in [Markdown](http://daringfireball.net)!!!`;
+
+class MarkdownSnippetExample extends React.Component {
+  render() {
+    return (
+      <div>
+        <h4>Standard</h4>
+        <MarkdownSnippet
+          markdown={markdown}
+        />
+
+        <h4>Without default styles</h4>
+        <MarkdownSnippet
+          defaultStyles={false}
+          markdown={markdown}
+        />
+
+        <h4>Change link target</h4>
+        <MarkdownSnippet
+          markdown={markdown}
+          linkTarget="_blank"
+        />
+      </div>
+    );
+  }
+}
+
+export default MarkdownSnippetExample;

--- a/packages/markdown-snippet/index.js
+++ b/packages/markdown-snippet/index.js
@@ -1,0 +1,60 @@
+import React from 'react/addons';
+import marked from 'marked';
+
+import SuitClassSet from '../suit-class-set';
+
+import './style';
+
+class MarkdownSnippet extends React.Component {
+  static propTypes = {
+    className: React.PropTypes.string,
+    defaultStyles: React.PropTypes.bool,
+    linkTarget: React.PropTypes.oneOf([
+      '_self',
+      '_blank',
+      '_parent',
+      '_top',
+    ]),
+    markdown: React.PropTypes.string.isRequired,
+  };
+
+  static defaultProps = {
+    defaultStyles: true,
+    linkTarget: '_self',
+    markdown: '',
+  };
+
+  componentWillMount() {
+    // Monkey patching of Marked
+    this.renderer = new marked.Renderer();
+    const linkRenderer = this.renderer.link;
+    this.renderer.link = (href, title, text) => linkRenderer.call(this.renderer, href, title, text).replace(/<a /, `<a target="${this.renderer.link.linkTarget || '_self'}" `);
+  }
+
+  render() {
+    const classSet = new SuitClassSet('MarkdownSnippet');
+
+    classSet.addModifier({
+      'defaultStyles': this.props.defaultStyles,
+    });
+
+    this.renderer.link.linkTarget = this.props.linkTarget;
+
+    let classNames = [classSet.toString()];
+
+    if (this.props.className) {
+      classNames.push(this.props.className);
+    }
+
+    return (
+      <div
+        className={classNames.join(' ')}
+        dangerouslySetInnerHTML={{
+          __html: marked(this.props.markdown, {sanitize: true, renderer: this.renderer}),
+        }}
+      />
+    );
+  }
+}
+
+export default MarkdownSnippet;

--- a/packages/markdown-snippet/style.scss
+++ b/packages/markdown-snippet/style.scss
@@ -1,0 +1,45 @@
+.MarkdownSnippet {
+  & > *:first-child {
+    margin-top: 0;
+  }
+
+  & > *:last-child {
+    margin-bottom: 0;
+  }
+
+  &.MarkdownSnippet--defaultStyles {
+    blockquote {
+      margin: 0;
+      padding: 0 15px;
+      color: #777;
+      border-left: 4px solid #ddd;
+    }
+
+    code {
+      padding: 0.2em;
+      margin: 0;
+      font-size: 85%;
+      background-color: rgba(0,0,0,0.04);
+      border-radius: 3px;
+    }
+
+    img {
+      max-width: 100%;
+    }
+
+    pre {
+      padding: 16px;
+      overflow: auto;
+      font-size: 85%;
+      line-height: 1.45;
+      background-color: #f7f7f7;
+      border-radius: 3px;
+
+      code {
+        background-color: transparent;
+        font-size: 1em;
+        padding: 0;
+      }
+    }
+  }
+}


### PR DESCRIPTION
`MarkdownSnippet` is a component for rendering formatted Markdown. Hopefully one day it'll be used inside MarkdownEdit, but for now it's its own thing.