### PR TITLE
Remove inner shadow from text inputs on iOS

### DIFF
--- a/style/inputs.scss
+++ b/style/inputs.scss
@@ -37,6 +37,11 @@ $input-state-error: #d46060;
   transition: all .1s;
   font-family: inherit;
   font-size: inherit;
+  /* Hide inner shadow on iOS */
+  -webkit-appearance: caret;
+  -moz-appearance: caret;
+  -o-appearance: caret;
+  appearance: caret;
 
   &::placeholder {
     color: $input-placeholder-color;


### PR DESCRIPTION
<img width="48%" alt="screen shot 2015-07-29 at 3 39 49 pm" src="https://cloud.githubusercontent.com/assets/282113/8950697/2fe02c44-3608-11e5-9742-71ff3760f395.png"><img width="48%" alt="screen shot 2015-07-29 at 3 40 06 pm" src="https://cloud.githubusercontent.com/assets/282113/8950696/2fdf3794-3608-11e5-9175-971b445e347e.png">