### PR TITLE
Only preventDefault() in modal handleClose() if it's called as an event handler

### DIFF
--- a/packages/modal/index.jsx
+++ b/packages/modal/index.jsx
@@ -60,7 +60,9 @@ module.exports = React.createClass({
   },
 
   handleClose(evt) {
-    evt.preventDefault();
+    if (evt) {
+      evt.preventDefault();
+    }
     if (!this.isMounted()) {
       return;
     }


### PR DESCRIPTION
Closing the modal using the esc key calls handleClose() without an
event.