### PR TITLE
Remove default button margin in Safari

### DIFF
--- a/packages/button/button.mcss
+++ b/packages/button/button.mcss
@@ -6,7 +6,7 @@
   display: inline-block;
   border: 0;
   border-radius: .3em;
-  margin-bottom: 0;
+  margin: 0;
   padding: .8em 1.5em;
   line-height: 1.25em;
   font-size: 0.8em;


### PR DESCRIPTION
For some reason Safari's buttons have a 2px margin by default. This is inconsistent with other browsers.