### PR TITLE
bump macropod-tools 0.0.28

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "css-modules-conversion-analysis": "0.0.1",
     "babel": "^5.8.21",
     "html-loader": "^0.2.3",
-    "macropod-tools": "0.0.27",
+    "macropod-tools": "0.0.28",
     "markdown-loader": "^0.1.2",
     "normalize.css": "~3.0.2",
     "react": ">=0.12.0",


### PR DESCRIPTION
- removes css simple vars (not used anyway)
- autoprefixes mcss to latest 3 versions