### PR TITLE
Fix an issue with the hot reload

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,6 +2,10 @@ var config = require('macropod-tools/webpack.config');
 
 config.module.loaders.push({test: /\.md$/, loaders: ['html-loader', 'markdown-loader']});
 
+// De-prioritise loading `.js` files so `.jsx` files take priority.
+config.resolve.extensions.splice(config.resolve.extensions.indexOf('.js'), 1);
+config.resolve.extensions.push('.js');
+
 if (typeof config.resolve.alias !== 'object') {
   config.resolve.alias = {};
 }


### PR DESCRIPTION
`.js` files took priority over `.jsx` files and as such the examples would only ever load the compiled versions. Rearranging the priority here fixes this behaviour.