### PR TITLE
react peer dependency lock

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,12 +21,12 @@
     "macropod-tools": "0.0.28",
     "markdown-loader": "^0.1.2",
     "normalize.css": "~3.0.2",
-    "react": "~0.13.3",
+    "react": "^0.13.3",
     "react-a11y": "^0.2.6",
     "react-router": ">=0.12.0"
   },
   "peerDependencies": {
-    "react": ">=0.12.0",
+    "react": "^0.13.3",
     "react-router": ">=0.12.0"
   },
   "scripts": {


### PR DESCRIPTION
lock 'em to react 13.x, to avoid react 14.x resulting in errors