### PR TITLE
Handle errors more gracefully in InputText

### DIFF
--- a/packages/form/input-text.jsx
+++ b/packages/form/input-text.jsx
@@ -60,17 +60,18 @@ export default React.createClass({
 
   handleUnmanagedChange() {
     const target = this.refs.input.getDOMNode();
+    const lastValue = this.handleUnmanagedChange.lastValue;
 
     if (target.value !== this.handleUnmanagedChange.lastValue) {
-      if (typeof this.handleUnmanagedChange.lastValue !== 'undefined') {
+      this.handleUnmanagedChange.lastValue = target.value;
+
+      if (typeof lastValue !== 'undefined') {
         this.props.onChange({
           currentTarget: target,
           target,
           timeStamp: Date.now(),
         });
       }
-
-      this.handleUnmanagedChange.lastValue = target.value;
     }
   },
 


### PR DESCRIPTION
- when the onChange handler failed, it would continue trying to call it indefinitely. This makes sure the check will pass after the first call.