### PR TITLE
Fix `react-router` dependency strictness

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,11 +22,11 @@
     "normalize.css": "~3.0.2",
     "react": "^0.13.3",
     "react-a11y": "^0.2.6",
-    "react-router": ">=0.12.0"
+    "react-router": "^0.13.4"
   },
   "peerDependencies": {
     "react": "^0.13.3",
-    "react-router": ">=0.12.0"
+    "react-router": "^0.13.4"
   },
   "scripts": {
     "start": "macropod-start",


### PR DESCRIPTION
This was pulling in 1.0.0, which has a bunch of API changes and we're not ready for just yet!